### PR TITLE
fix(footer): make copyright year dynamic

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -10,6 +10,7 @@ import { getLink, getTranslator } from "../lib/i18n.ts";
 import Faro from "./faro.astro";
 
 const __ = await getTranslator(Astro.currentLocale);
+const year = new Date().getFullYear()
 
 const menus = [
   {
@@ -87,7 +88,7 @@ type Props = {
   <p
     class="text-tertiary-foreground text-xxs container flex items-center gap-3"
   >
-    {__("Copyright © 2025 Probo. All rights reserved.")}
+    {`Copyright © ${year} Probo. All rights reserved.`}
     <OpenStatus client:visible />
   </p>
 </footer>


### PR DESCRIPTION
## Description

This MR fixes the issue where the footer year was hardcoded and did not update automatically.

The copyright year is now generated dynamically using `new Date().getFullYear()` in `footer.astro`, ensuring that it always shows the current year.

## Issue
Fixes: #11 

## Changes
- Updated `footer.astro` to use a dynamic year:
