### PR TITLE
Update S3 compatible documentation

### DIFF
--- a/src/content/docs/docs/configuration/config-file.mdx
+++ b/src/content/docs/docs/configuration/config-file.mdx
@@ -430,7 +430,7 @@ AWS secret access key for authentication. When omitted, probod will attempt to u
 
 **Optional**
 
-Custom S3-compatible endpoint URL. Useful for local development with MinIO or other S3-compatible services.
+Custom S3-compatible endpoint URL. Useful for local development with SeaweedFS or other S3-compatible services.
 
 ### Notifications Configuration
 

--- a/src/content/docs/docs/configuration/environment-variables.mdx
+++ b/src/content/docs/docs/configuration/environment-variables.mdx
@@ -116,13 +116,14 @@ When running Probo in Docker:
 
 ## AWS / S3 Storage
 
-| Variable                | Description                                              | Default Value | Required |
-| ----------------------- | -------------------------------------------------------- | ------------- | -------- |
-| `AWS_REGION`            | AWS region for S3 storage                                | `us-east-1`   | No       |
-| `AWS_BUCKET`            | S3 bucket name for file storage                          | `probod`      | No       |
-| `AWS_ACCESS_KEY_ID`     | AWS access key ID (leave empty for IAM role)             | -             | No       |
-| `AWS_SECRET_ACCESS_KEY` | AWS secret access key (leave empty for IAM role)         | -             | No       |
-| `AWS_ENDPOINT`          | Custom S3 endpoint (for MinIO or S3-compatible services) | -             | No       |
+| Variable                | Description                                                  | Default Value | Required |
+| ----------------------- | ------------------------------------------------------------ | ------------- | -------- |
+| `AWS_REGION`            | AWS region for S3 storage                                    | `us-east-1`   | No       |
+| `AWS_BUCKET`            | S3 bucket name for file storage                              | `probod`      | No       |
+| `AWS_ACCESS_KEY_ID`     | AWS access key ID (leave empty for IAM role)                 | -             | No       |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret access key (leave empty for IAM role)             | -             | No       |
+| `AWS_ENDPOINT`          | Custom S3 endpoint (for SeaweedFS or S3-compatible services) | -             | No       |
+| `AWS_USE_PATH_STYLE`    | Use path-style URLs (required for SeaweedFS)                 | `false`       | No       |
 
 ## Notifications
 

--- a/src/content/docs/docs/self-hosting/docker-compose.mdx
+++ b/src/content/docs/docs/self-hosting/docker-compose.mdx
@@ -134,8 +134,8 @@ services:
       # Remove AWS_ENDPOINT for AWS S3
       # AWS_ENDPOINT: ""
 
-# Remove MinIO service
-minio:
+# Remove SeaweedFS service
+seaweedfs:
   deploy:
     replicas: 0
 ```
@@ -148,7 +148,7 @@ The Docker Compose deployment includes:
 
 - **probo** - Main application (ports 8080, 8081, 8443)
 - **postgres** - PostgreSQL database (port 5432)
-- **minio** - S3-compatible storage (ports 9000, 9001)
+- **seaweedfs** - S3-compatible storage (port 8333 for S3 API, 9333 for master)
 - **chrome** - PDF generation service (port 9222)
 
 ### Networking
@@ -159,7 +159,7 @@ Services communicate over a dedicated Docker network with automatic service disc
 
 - **probo-data** - Application data and uploads
 - **postgres-data** - Database files
-- **minio-data** - Object storage files
+- **seaweedfs-data** - Object storage files
 
 ## Load Balancer Setup
 
@@ -231,8 +231,8 @@ curl http://localhost:8081/metrics
 # Database connectivity
 docker compose exec postgres pg_isready -U postgres
 
-# MinIO health
-curl http://localhost:9000/minio/health/live
+# SeaweedFS health
+curl http://localhost:9333/cluster/status
 ```
 
 ### Log Management
@@ -264,13 +264,13 @@ docker compose exec -T postgres psql -U postgres probod < backup.sql
 ### File Storage Backup
 
 ```bash
-# Backup MinIO data
-docker run --rm -v probo_minio-data:/data -v $(pwd):/backup alpine \
-  tar czf /backup/minio-backup.tar.gz -C /data .
+# Backup SeaweedFS data
+docker run --rm -v probo_seaweedfs-data:/data -v $(pwd):/backup alpine \
+  tar czf /backup/seaweedfs-backup.tar.gz -C /data .
 
-# Restore MinIO data
-docker run --rm -v probo_minio-data:/data -v $(pwd):/backup alpine \
-  tar xzf /backup/minio-backup.tar.gz -C /data
+# Restore SeaweedFS data
+docker run --rm -v probo_seaweedfs-data:/data -v $(pwd):/backup alpine \
+  tar xzf /backup/seaweedfs-backup.tar.gz -C /data
 ```
 
 ## Troubleshooting

--- a/src/content/docs/docs/self-hosting/kubernetes.mdx
+++ b/src/content/docs/docs/self-hosting/kubernetes.mdx
@@ -57,11 +57,11 @@ Kubernetes deployment provides the most scalable and production-ready way to run
     --set postgresql.enabled=false \
     --set postgresql.host="your-managed-db.example.com" \
     --set postgresql.password="your-db-password" \
-    --set minio.enabled=false \
-    --set s3.region="us-east-1" \
-    --set s3.bucket="your-bucket-name" \
-    --set s3.accessKeyId="your-access-key" \
-    --set s3.secretAccessKey="your-secret-key"
+   --set seaweedfs.enabled=false \
+   --set s3.region="us-east-1" \
+   --set s3.bucket="your-bucket-name" \
+   --set s3.accessKeyId="your-access-key" \
+   --set s3.secretAccessKey="your-secret-key"
    ```
 
 4. Access the Application
@@ -123,7 +123,7 @@ postgresql:
   host: "your-managed-db.example.com"
   password: "your-secure-db-password"
 
-minio:
+seaweedfs:
   enabled: false
 
 # Production S3 configuration
@@ -132,6 +132,7 @@ s3:
   bucket: "your-production-bucket"
   accessKeyId: "your-access-key"
   secretAccessKey: "your-secret-key"
+  # usePathStyle: true  # Required for SeaweedFS — AWS_USE_PATH_STYLE forces path-style URLs (e.g. host/bucket) instead of virtual-hosted (bucket.host)
 
 # Resource limits
 resources:
@@ -196,7 +197,7 @@ helm install probo ./charts/probo \
   --set postgresql.enabled=false \
   --set postgresql.host="mydb.abc123.us-east-1.rds.amazonaws.com" \
   --set postgresql.password="$RDS_PASSWORD" \
-  --set minio.enabled=false \
+  --set seaweedfs.enabled=false \
   --set s3.region="us-east-1" \
   --set s3.bucket="my-probo-bucket" \
   --set s3.accessKeyId="$AWS_ACCESS_KEY" \
@@ -219,7 +220,7 @@ helm install probo ./charts/probo \
   --set postgresql.enabled=false \
   --set postgresql.host="10.0.0.5" \
   --set postgresql.password="$CLOUDSQL_PASSWORD" \
-  --set minio.enabled=false \
+  --set seaweedfs.enabled=false \
   --set s3.endpoint="https://storage.googleapis.com" \
   --set s3.bucket="my-probo-bucket" \
   --set s3.accessKeyId="$HMAC_ACCESS_KEY" \
@@ -242,7 +243,7 @@ helm install probo ./charts/probo \
   --set postgresql.enabled=false \
   --set postgresql.host="mydb.postgres.database.azure.com" \
   --set postgresql.password="$AZURE_DB_PASSWORD" \
-  --set minio.enabled=false \
+  --set seaweedfs.enabled=false \
   --set s3.endpoint="https://mystorageaccount.blob.core.windows.net" \
   --set s3.bucket="my-probo-container" \
   --set s3.usePathStyle=true \


### PR DESCRIPTION
Replace MinIO with SeaweedFS in documentation

- Updates all documentation references from MinIO to SeaweedFS across the self-hosting and configuration docs.
Replace minio with seaweedfs in Kubernetes and Docker Compose deployment guides (service names, volume names, ports, health check URL, backup commands)

- Add AWS_USE_PATH_STYLE environment variable to the S3 storage reference table

- Add a commented usePathStyle hint in the Kubernetes production values example, explaining when AWS_USE_PATH_STYLE is needed

- Update S3 endpoint descriptions in config-file.mdx and environment-variables.mdx
