### PR TITLE
Add JSON-LD structured data to key pages

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,12 +12,26 @@ import Stories from "../components/block/Stories.astro";
 import ComplianceTrack from "../components/block/ComplianceTrack.astro";
 import { getTranslator, getLink } from "../lib/i18n.ts";
 const __ = await getTranslator(Astro.currentLocale)
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  "name": "Probo",
+  "alternateName": "Probo Compliance",
+  "url": "https://www.getprobo.com",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Probo",
+    "url": "https://www.getprobo.com"
+  }
+};
 ---
 
 <Layout
   title={__("Probo - Compliance done for you")}
   description={__("Get SOC 2, GDPR, HIPAA, and ISO certified with expert guidance and the job done for you. Open-source compliance management platform with no vendor lock-in. Backed by Y Combinator.")}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(websiteSchema)} />
   <animated-hero class="block py-10 pt-26 sm:pt-36 sm:pb-12 relative overflow-hidden px-5 -mt-16">
     <a
       href="https://www.ycombinator.com/companies/probo"

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -4,12 +4,42 @@ import Button from "../components/ui/Button.svelte";
 import { getTranslator, getLink } from "../lib/i18n.ts";
 
 const __ = await getTranslator(Astro.currentLocale);
+
+const serviceSchema = {
+  "@context": "https://schema.org",
+  "@type": "Service",
+  "name": "Probo Full-Service Compliance",
+  "description": "End-to-end compliance management service for SOC 2, ISO 27001, GDPR, and HIPAA.",
+  "provider": {
+    "@type": "Organization",
+    "name": "Probo",
+    "url": "https://www.getprobo.com"
+  },
+  "serviceType": "Compliance Management",
+  "areaServed": {
+    "@type": "Place",
+    "name": "Worldwide"
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "8000",
+    "priceCurrency": "USD",
+    "priceSpecification": {
+      "@type": "UnitPriceSpecification",
+      "price": "8000",
+      "priceCurrency": "USD",
+      "unitText": "year"
+    },
+    "url": "https://www.getprobo.com/pricing"
+  }
+};
 ---
 
 <Layout
   title={__("Pricing")}
   description={__("We Handle Your Compliance. Probo isn't another compliance dashboard. We're your dedicated compliance team. Starting at $8,000 per year.")}
 >
+  <script type="application/ld+json" set:html={JSON.stringify(serviceSchema)} />
     <!-- Hero Section -->
     <animated-hero class="block py-16 sm:py-24 relative overflow-hidden">
       <div class="container text-center">

--- a/src/pages/stories/_page.astro
+++ b/src/pages/stories/_page.astro
@@ -23,9 +23,36 @@ const images = dynamicImages(
 const image = images(data.image);
 const logo = images(data.logo);
 const stories = random((await getCollection("stories", filterLang(Astro.currentLocale))).filter(s => s.id !== item.id), 3);
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": data.title,
+  ...(data.description && { "description": data.description }),
+  "datePublished": data.date.toISOString(),
+  "author": {
+    "@type": "Organization",
+    "name": "Probo",
+    "url": "https://www.getprobo.com"
+  },
+  "publisher": {
+    "@type": "Organization",
+    "name": "Probo",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://www.getprobo.com/probo-logo.svg"
+    }
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": Astro.url.toString()
+  },
+  "image": data.ogImage ? `https://www.getprobo.com${data.ogImage}` : "https://www.getprobo.com/og.png"
+};
 ---
 
 <Layout title={item.data.title} description={item.data.description} ogImage={item.data.ogImage}>
+  <script type="application/ld+json" set:html={JSON.stringify(articleSchema)} />
   <header class="relative flex h-115 flex-col justify-end sm:h-163">
     <Image
       src={image}


### PR DESCRIPTION
Add WebSite schema on homepage, Service schema with pricing offer on pricing page, and Article schema on customer story pages. Improves SEO and enables rich results in Google Search.

Files changed:
- `src/pages/index.astro` — WebSite schema
- `src/pages/pricing.astro` — Service schema with Offer
- `src/pages/stories/_page.astro` — Article schema for case studies