### PR TITLE
Restructure docs sidebar: flatten API and Product sections

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -145,18 +145,23 @@ export default defineConfig({
           ],
         },
         {
-          label: "Product",
+          label: "SSO",
           items: [
+            { label: "Overview", slug: "docs/product/sso/overview" },
             {
-              label: "SSO",
-              items: [
-                { label: "Overview", slug: "docs/product/sso/overview" },
-                {
-                  label: "Google Workspace",
-                  slug: "docs/product/sso/google-workspace",
-                },
-                { label: "Okta", slug: "docs/product/sso/okta" },
-              ],
+              label: "Google Workspace",
+              slug: "docs/product/sso/google-workspace",
+            },
+            { label: "Okta", slug: "docs/product/sso/okta" },
+          ],
+        },
+        {
+          label: "SCIM",
+          items: [
+            { label: "Overview", slug: "docs/product/scim/overview" },
+            {
+              label: "Google Workspace",
+              slug: "docs/product/scim/google-workspace",
             },
           ],
         },
@@ -214,139 +219,160 @@ export default defineConfig({
           ],
         },
         {
-          label: "API",
+          label: "MCP",
           items: [
+            { label: "Overview", slug: "docs/api/mcp/overview" },
             {
-              label: "MCP",
-              badge: "New",
+              label: "Authentication",
+              slug: "docs/api/mcp/authentication",
+            },
+            { label: "Pagination", slug: "docs/api/mcp/pagination" },
+            {
+              label: "Available Tools",
+              collapsed: true,
               items: [
-                { label: "Overview", slug: "docs/api/mcp/overview" },
                 {
-                  label: "Authentication",
-                  slug: "docs/api/mcp/authentication",
-                },
-                { label: "Pagination", slug: "docs/api/mcp/pagination" },
-                {
-                  label: "Available Tools",
-                  collapsed: true,
-                  items: [
-                    {
-                      label: "Overview",
-                      slug: "docs/api/mcp/tools",
-                    },
-                    {
-                      label: "Organizations",
-                      slug: "docs/api/mcp/tools/organizations",
-                    },
-                    {
-                      label: "Users",
-                      slug: "docs/api/mcp/tools/users",
-                    },
-                    {
-                      label: "Vendors",
-                      slug: "docs/api/mcp/tools/vendors",
-                    },
-                    {
-                      label: "Risks",
-                      slug: "docs/api/mcp/tools/risks",
-                    },
-                    {
-                      label: "Measures",
-                      slug: "docs/api/mcp/tools/measures",
-                    },
-                    {
-                      label: "Frameworks",
-                      slug: "docs/api/mcp/tools/frameworks",
-                    },
-                    {
-                      label: "Controls",
-                      slug: "docs/api/mcp/tools/controls",
-                    },
-                    {
-                      label: "Assets",
-                      slug: "docs/api/mcp/tools/assets",
-                    },
-                    {
-                      label: "Audits",
-                      slug: "docs/api/mcp/tools/audits",
-                    },
-                    {
-                      label: "Tasks",
-                      slug: "docs/api/mcp/tools/tasks",
-                    },
-                    {
-                      label: "Documents",
-                      slug: "docs/api/mcp/tools/documents",
-                    },
-                    {
-                      label: "Meetings",
-                      slug: "docs/api/mcp/tools/meetings",
-                    },
-                    {
-                      label: "Snapshots",
-                      slug: "docs/api/mcp/tools/snapshots",
-                    },
-                    {
-                      label: "States of Applicability",
-                      slug: "docs/api/mcp/tools/states-of-applicability",
-                    },
-                    {
-                      label: "Findings",
-                      slug: "docs/api/mcp/tools/findings",
-                    },
-                    {
-                      label: "Obligations",
-                      slug: "docs/api/mcp/tools/obligations",
-                    },
-                    {
-                      label: "Data Classification",
-                      slug: "docs/api/mcp/tools/data-classification",
-                    },
-                    {
-                      label: "Processing Activities",
-                      slug: "docs/api/mcp/tools/processing-activities",
-                    },
-                    {
-                      label: "DPIAs",
-                      slug: "docs/api/mcp/tools/dpias",
-                    },
-                    {
-                      label: "TIAs",
-                      slug: "docs/api/mcp/tools/tias",
-                    },
-                  ],
+                  label: "Overview",
+                  slug: "docs/api/mcp/tools",
                 },
                 {
-                  label: "Integrations",
-                  items: [
-                    {
-                      label: "Overview",
-                      slug: "docs/api/mcp/integrations",
-                    },
-                    {
-                      label: "Claude Desktop",
-                      slug: "docs/api/mcp/claude-desktop",
-                    },
-                    {
-                      label: "Claude Code",
-                      slug: "docs/api/mcp/claude-code",
-                    },
-                    {
-                      label: "Claude.ai",
-                      slug: "docs/api/mcp/claude-ai",
-                    },
-                    { label: "Cursor", slug: "docs/api/mcp/cursor" },
-                    { label: "Windsurf", slug: "docs/api/mcp/windsurf" },
-                    { label: "Zed", slug: "docs/api/mcp/zed" },
-                    {
-                      label: "Opencode AI",
-                      slug: "docs/api/mcp/opencode",
-                    },
-                    { label: "VS Code", slug: "docs/api/mcp/vscode" },
-                    { label: "OpenAI", slug: "docs/api/mcp/openai" },
-                  ],
+                  label: "Organizations",
+                  slug: "docs/api/mcp/tools/organizations",
+                },
+                {
+                  label: "Users",
+                  slug: "docs/api/mcp/tools/users",
+                },
+                {
+                  label: "Vendors",
+                  slug: "docs/api/mcp/tools/vendors",
+                },
+                {
+                  label: "Risks",
+                  slug: "docs/api/mcp/tools/risks",
+                },
+                {
+                  label: "Measures",
+                  slug: "docs/api/mcp/tools/measures",
+                },
+                {
+                  label: "Frameworks",
+                  slug: "docs/api/mcp/tools/frameworks",
+                },
+                {
+                  label: "Controls",
+                  slug: "docs/api/mcp/tools/controls",
+                },
+                {
+                  label: "Assets",
+                  slug: "docs/api/mcp/tools/assets",
+                },
+                {
+                  label: "Audits",
+                  slug: "docs/api/mcp/tools/audits",
+                },
+                {
+                  label: "Tasks",
+                  slug: "docs/api/mcp/tools/tasks",
+                },
+                {
+                  label: "Documents",
+                  slug: "docs/api/mcp/tools/documents",
+                },
+                {
+                  label: "Meetings",
+                  slug: "docs/api/mcp/tools/meetings",
+                },
+                {
+                  label: "Snapshots",
+                  slug: "docs/api/mcp/tools/snapshots",
+                },
+                {
+                  label: "States of Applicability",
+                  slug: "docs/api/mcp/tools/states-of-applicability",
+                },
+                {
+                  label: "Findings",
+                  slug: "docs/api/mcp/tools/findings",
+                },
+                {
+                  label: "Obligations",
+                  slug: "docs/api/mcp/tools/obligations",
+                },
+                {
+                  label: "Data Classification",
+                  slug: "docs/api/mcp/tools/data-classification",
+                },
+                {
+                  label: "Processing Activities",
+                  slug: "docs/api/mcp/tools/processing-activities",
+                },
+                {
+                  label: "DPIAs",
+                  slug: "docs/api/mcp/tools/dpias",
+                },
+                {
+                  label: "TIAs",
+                  slug: "docs/api/mcp/tools/tias",
                 },
               ],
+            },
+            {
+              label: "Integrations",
+              collapsed: true,
+              items: [
+                {
+                  label: "Overview",
+                  slug: "docs/api/mcp/integrations",
+                },
+                {
+                  label: "Claude Desktop",
+                  slug: "docs/api/mcp/claude-desktop",
+                },
+                {
+                  label: "Claude Code",
+                  slug: "docs/api/mcp/claude-code",
+                },
+                {
+                  label: "Claude.ai",
+                  slug: "docs/api/mcp/claude-ai",
+                },
+                { label: "Cursor", slug: "docs/api/mcp/cursor" },
+                { label: "Windsurf", slug: "docs/api/mcp/windsurf" },
+                { label: "Zed", slug: "docs/api/mcp/zed" },
+                {
+                  label: "Opencode AI",
+                  slug: "docs/api/mcp/opencode",
+                },
+                { label: "VS Code", slug: "docs/api/mcp/vscode" },
+                { label: "OpenAI", slug: "docs/api/mcp/openai" },
+              ],
+            },
+          ],
+        },
+        {
+          label: "n8n",
+          items: [
+            { label: "Overview", slug: "docs/api/n8n/overview" },
+            {
+              label: "Authentication",
+              slug: "docs/api/n8n/authentication",
+            },
+            { label: "Resources", slug: "docs/api/n8n/resources" },
+            { label: "GraphQL", slug: "docs/api/n8n/graphql" },
+          ],
+        },
+        {
+          label: "Webhooks",
+          items: [
+            { label: "Overview", slug: "docs/api/webhooks/overview" },
+            {
+              label: "Event Types",
+              slug: "docs/api/webhooks/event-types",
+            },
+            {
+              label: "Signature Verification",
+              slug: "docs/api/webhooks/signature-verification",
             },
           ],
         },

--- a/src/content/docs/docs/api/n8n/authentication.mdx
+++ b/src/content/docs/docs/api/n8n/authentication.mdx
@@ -1,0 +1,49 @@
+---
+title: n8n Authentication
+description: Configure Probo API credentials in your n8n instance
+---
+
+import { Steps } from '@astrojs/starlight/components';
+
+The Probo n8n node authenticates using an API key sent as a Bearer token. You need to create credentials in n8n before using any Probo node.
+
+## Creating credentials
+
+<Steps>
+
+1. **Add a Probo node to your workflow**
+
+   Search for "Probo" in the n8n node palette and drag it onto your canvas.
+
+2. **Open the credentials dialog**
+
+   Click the **Credential** dropdown in the node and select **Create New Credential**.
+
+3. **Configure the connection**
+
+   | Field | Default | Description |
+   |---|---|---|
+   | **Probo Server** | `https://us.console.getprobo.com` | Your Probo instance URL. Change this if you use a different region or self-host Probo. |
+   | **API Key** | — | Your Probo API key |
+
+4. **Test the connection**
+
+   Click **Test** to verify that n8n can reach your Probo instance and that the API key is valid. The node validates credentials by querying the authenticated user's identity.
+
+5. **Save**
+
+   Click **Save** to store the credentials. They'll be available to all Probo nodes in your workflows.
+
+</Steps>
+
+## Getting an API key
+
+You can generate an API key from the Probo console:
+
+1. Go to **Settings** → **API Keys** in your Probo organization.
+2. Click **Create API Key**.
+3. Copy the key — it won't be shown again.
+
+## Self-hosted instances
+
+If you're running a self-hosted Probo instance, set the **Probo Server** field to your instance URL (e.g., `https://probo.internal.example.com`). The node connects to the GraphQL API at `/api/console/v1/graphql`.

--- a/src/content/docs/docs/api/n8n/graphql.mdx
+++ b/src/content/docs/docs/api/n8n/graphql.mdx
@@ -1,0 +1,79 @@
+---
+title: n8n GraphQL
+description: Execute custom GraphQL queries against Probo APIs from n8n
+---
+
+The Probo n8n node includes a **GraphQL** resource that lets you run arbitrary GraphQL queries and mutations against the Probo APIs. Use this for advanced use cases not covered by the built-in resource operations.
+
+## Configuration
+
+| Field | Description |
+|---|---|
+| **API** | Which Probo API to call: **Console API** (`/api/console/v1/graphql`) or **Connect API** (`/api/connect/v1/graphql`) |
+| **Query** | The full GraphQL operation, including operation type, name, and variable declarations |
+| **Variables** | A JSON object containing the variables referenced in your query |
+
+## Example: Query
+
+Fetch a specific user by ID:
+
+**Query:**
+```graphql
+query GetUser($userId: ID!) {
+  node(id: $userId) {
+    ... on User {
+      id
+      fullName
+      email
+    }
+  }
+}
+```
+
+**Variables:**
+```json
+{
+  "userId": "usr_abc123"
+}
+```
+
+## Example: Mutation
+
+Update an organization name:
+
+**Query:**
+```graphql
+mutation UpdateOrganization($input: UpdateOrganizationInput!) {
+  updateOrganization(input: $input) {
+    organization {
+      id
+      name
+    }
+  }
+}
+```
+
+**Variables:**
+```json
+{
+  "input": {
+    "id": "org_abc123",
+    "name": "Acme Corp"
+  }
+}
+```
+
+## Requirements
+
+- The query **must** start with `query`, `mutation`, or `subscription` followed by an operation name.
+- Anonymous queries (e.g., `{ viewer { id } }`) are not supported — always name your operations.
+- Variables must be valid JSON.
+
+## When to use GraphQL
+
+Use the GraphQL resource when you need to:
+
+- Access fields or relationships not exposed by the built-in resource operations
+- Run complex queries that combine multiple resources in a single request
+- Use the Connect API (most built-in resources use the Console API)
+- Perform batch operations with custom variable logic

--- a/src/content/docs/docs/api/n8n/overview.mdx
+++ b/src/content/docs/docs/api/n8n/overview.mdx
@@ -1,0 +1,80 @@
+---
+title: n8n Integration
+description: Automate your compliance workflows with the Probo n8n community node
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
+
+The [Probo n8n node](https://www.npmjs.com/package/@probo/n8n-nodes-probo) (`@probo/n8n-nodes-probo`) lets you integrate Probo into your n8n workflows. Automate compliance tasks like syncing risks, creating audits, managing vendors, and more — all from your n8n instance.
+
+## Installation
+
+<Steps>
+
+1. **Open your n8n instance settings**
+
+   Go to **Settings** → **Community nodes**.
+
+2. **Install the package**
+
+   Enter the package name:
+
+   ```
+   @probo/n8n-nodes-probo
+   ```
+
+   Click **Install**. The Probo node will appear in your node palette.
+
+3. **Configure credentials**
+
+   When you first add a Probo node to a workflow, you'll be prompted to create credentials. See [Authentication](/docs/api/n8n/authentication) for details.
+
+</Steps>
+
+## Available resources
+
+The Probo node supports 12 resource types covering the full compliance platform:
+
+| Resource | Operations | Description |
+|---|---|---|
+| **Organization** | Create, Get, Get Many, Update, Delete | Manage organizations |
+| **User** | Create, Get, List, Invite, Update, Update Membership, Remove | Manage users and memberships |
+| **Framework** | Create, Get, Get Many, Update, Delete | Manage compliance frameworks |
+| **Control** | Create, Get, Get Many, Update, Delete | Manage framework controls |
+| **Risk** | Create, Get, Get Many, Update, Delete, Link/Unlink Document, Link/Unlink Measure, Link/Unlink Obligation | Manage risks and their relationships |
+| **Measure** | Create, Get, Get Many, Update, Delete | Manage security measures |
+| **Asset** | Create, Get, Get Many, Update, Delete | Manage assets |
+| **Audit** | Create, Get, Get Many, Update, Delete, Upload Report, Delete Report | Manage audits and reports |
+| **Vendor** | Create, Get, Get Many, Update, Delete, plus Contacts, Services, and Risk Assessments sub-resources | Manage vendors and related data |
+| **Meeting** | Create, Get, Get Many, Update, Delete | Manage meetings |
+| **Data Classification** | Create, Get, Get Many, Update, Delete | Manage data classification entries |
+| **GraphQL** | Execute | Run arbitrary GraphQL queries against the Console or Connect API |
+
+## Use cases
+
+- **Sync vendors from external sources** — Pull vendor data from a spreadsheet or CRM and create/update vendors in Probo automatically.
+- **Automate risk creation from scan results** — Connect security scanning tools to Probo and create risks when new vulnerabilities are found.
+- **Schedule audit reminders** — Trigger workflows on a schedule to check audit status and send Slack or email notifications.
+- **Cross-platform compliance reporting** — Pull data from Probo and push it to reporting tools, dashboards, or document generators.
+- **Onboard new frameworks** — Automate the creation of frameworks, controls, and measures from a predefined template.
+
+## Next steps
+
+<CardGrid>
+  <LinkCard
+    title="Authentication"
+    description="Configure your Probo API credentials in n8n"
+    href="/docs/api/n8n/authentication"
+  />
+  <LinkCard
+    title="Resources"
+    description="Detailed reference for all available resources and operations"
+    href="/docs/api/n8n/resources"
+  />
+  <LinkCard
+    title="GraphQL"
+    description="Execute custom GraphQL queries for advanced use cases"
+    href="/docs/api/n8n/graphql"
+  />
+</CardGrid>

--- a/src/content/docs/docs/api/n8n/resources.mdx
+++ b/src/content/docs/docs/api/n8n/resources.mdx
@@ -1,0 +1,178 @@
+---
+title: n8n Resources
+description: Reference for all Probo n8n node resources and operations
+---
+
+The Probo n8n node organizes operations by resource type. Each resource supports a set of CRUD operations and, in some cases, specialized actions.
+
+## Organization
+
+Manage Probo organizations.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new organization |
+| Get | Get an organization by ID |
+| Get Many | List organizations |
+| Update | Update an existing organization |
+| Delete | Delete an organization |
+
+## User
+
+Manage users and organization memberships.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new user in the organization |
+| Get | Get a user profile by ID |
+| List | List all users in the organization |
+| Invite | Invite a user to the organization |
+| Update | Update a user profile |
+| Update Membership | Update a user's membership role |
+| Remove | Remove a user from the organization |
+
+## Framework
+
+Manage compliance frameworks (e.g., SOC 2, ISO 27001).
+
+| Operation | Description |
+|---|---|
+| Create | Create a new framework |
+| Get | Get a framework by ID |
+| Get Many | List frameworks |
+| Update | Update an existing framework |
+| Delete | Delete a framework |
+
+## Control
+
+Manage controls within frameworks.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new control |
+| Get | Get a control by ID |
+| Get Many | List controls |
+| Update | Update an existing control |
+| Delete | Delete a control |
+
+## Risk
+
+Manage risks and their relationships to documents, measures, and obligations.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new risk |
+| Get | Get a risk by ID |
+| Get Many | List risks |
+| Update | Update an existing risk |
+| Delete | Delete a risk |
+| Link Document | Link a document to a risk |
+| Unlink Document | Unlink a document from a risk |
+| Link Measure | Link a measure to a risk |
+| Unlink Measure | Unlink a measure from a risk |
+| Link Obligation | Link an obligation to a risk |
+| Unlink Obligation | Unlink an obligation from a risk |
+
+## Measure
+
+Manage security measures.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new measure |
+| Get | Get a measure by ID |
+| Get Many | List measures |
+| Update | Update an existing measure |
+| Delete | Delete a measure |
+
+## Asset
+
+Manage assets tracked in your compliance program.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new asset |
+| Get | Get an asset by ID |
+| Get Many | List assets |
+| Update | Update an existing asset |
+| Delete | Delete an asset |
+
+## Audit
+
+Manage audits and audit reports.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new audit |
+| Get | Get an audit by ID |
+| Get Many | List audits |
+| Update | Update an existing audit |
+| Delete | Delete an audit |
+| Upload Report | Upload a report file for an audit |
+| Delete Report | Delete an audit report |
+
+## Vendor
+
+Manage vendors, vendor contacts, vendor services, and vendor risk assessments.
+
+### Core operations
+
+| Operation | Description |
+|---|---|
+| Create | Create a new vendor |
+| Get | Get a vendor by ID |
+| Get Many | List vendors |
+| Update | Update an existing vendor |
+| Delete | Delete a vendor |
+
+### Contacts
+
+| Operation | Description |
+|---|---|
+| Create Contact | Create a new vendor contact |
+| Get Contact | Get a vendor contact |
+| Get Many Contacts | List vendor contacts |
+| Update Contact | Update a vendor contact |
+| Delete Contact | Delete a vendor contact |
+
+### Services
+
+| Operation | Description |
+|---|---|
+| Create Service | Create a new vendor service |
+| Get Service | Get a vendor service |
+| Get Many Services | List vendor services |
+| Update Service | Update a vendor service |
+| Delete Service | Delete a vendor service |
+
+### Risk assessments
+
+| Operation | Description |
+|---|---|
+| Create Risk Assessment | Create a new vendor risk assessment |
+| Get Risk Assessment | Get a vendor risk assessment |
+| Get Many Risk Assessments | List vendor risk assessments |
+
+## Meeting
+
+Manage meetings.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new meeting |
+| Get | Get a meeting by ID |
+| Get Many | List meetings |
+| Update | Update an existing meeting |
+| Delete | Delete a meeting |
+
+## Data Classification
+
+Manage data classification entries.
+
+| Operation | Description |
+|---|---|
+| Create | Create a new datum |
+| Get | Get a datum by ID |
+| Get Many | List data classification entries |
+| Update | Update an existing datum |
+| Delete | Delete a datum |

--- a/src/content/docs/docs/api/webhooks/event-types.mdx
+++ b/src/content/docs/docs/api/webhooks/event-types.mdx
@@ -1,0 +1,185 @@
+---
+title: Webhook Event Types
+description: Available webhook event types and their payload structures
+---
+
+Probo sends webhook events for four resource categories. Each resource supports `created`, `updated`, and `deleted` events.
+
+## Available events
+
+| Event | Description |
+|-------|-------------|
+| `meeting:created` | A meeting was created |
+| `meeting:updated` | A meeting was updated |
+| `meeting:deleted` | A meeting was deleted |
+| `vendor:created` | A vendor was created |
+| `vendor:updated` | A vendor was updated |
+| `vendor:deleted` | A vendor was deleted |
+| `user:created` | A user was created |
+| `user:updated` | A user was updated |
+| `user:deleted` | A user was deleted |
+| `obligation:created` | An obligation was created |
+| `obligation:updated` | An obligation was updated |
+| `obligation:deleted` | An obligation was deleted |
+
+## Payload structures
+
+The `data` field in the webhook payload contains the resource that triggered the event. Below are the fields for each resource type.
+
+### Meeting
+
+Sent for `meeting:created`, `meeting:updated`, and `meeting:deleted` events.
+
+```json
+{
+  "id": "mtg_01ABC123",
+  "name": "Q1 Risk Review",
+  "date": "2025-03-15T14:00:00Z",
+  "minutes": "Discussion notes...",
+  "createdAt": "2025-01-10T09:00:00Z",
+  "updatedAt": "2025-03-15T16:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Meeting identifier |
+| `name` | string | Meeting name |
+| `date` | string | Meeting date (RFC 3339) |
+| `minutes` | string \| null | Meeting minutes |
+| `createdAt` | string | Creation timestamp (RFC 3339) |
+| `updatedAt` | string | Last update timestamp (RFC 3339) |
+
+### Vendor
+
+Sent for `vendor:created`, `vendor:updated`, and `vendor:deleted` events.
+
+```json
+{
+  "id": "vnd_01DEF456",
+  "name": "Acme Cloud",
+  "category": "CLOUD_INFRASTRUCTURE",
+  "description": "Cloud hosting provider",
+  "statusPageUrl": "https://status.acme.cloud",
+  "termsOfServiceUrl": "https://acme.cloud/tos",
+  "privacyPolicyUrl": "https://acme.cloud/privacy",
+  "serviceLevelAgreementUrl": "https://acme.cloud/sla",
+  "dataProcessingAgreementUrl": null,
+  "businessAssociateAgreementUrl": null,
+  "subprocessorsListUrl": "https://acme.cloud/subprocessors",
+  "certifications": ["SOC2", "ISO27001"],
+  "countries": ["US", "DE"],
+  "securityPageUrl": "https://acme.cloud/security",
+  "trustPageUrl": "https://acme.cloud/trust",
+  "headquarterAddress": "123 Cloud St, San Francisco, CA",
+  "legalName": "Acme Cloud Inc.",
+  "websiteUrl": "https://acme.cloud",
+  "businessOwnerId": "usr_01GHI789",
+  "securityOwnerId": "usr_01JKL012",
+  "createdAt": "2025-01-05T10:00:00Z",
+  "updatedAt": "2025-01-05T10:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Vendor identifier |
+| `name` | string | Vendor name |
+| `category` | string | Vendor category |
+| `description` | string \| null | Description |
+| `statusPageUrl` | string \| null | Status page URL |
+| `termsOfServiceUrl` | string \| null | Terms of service URL |
+| `privacyPolicyUrl` | string \| null | Privacy policy URL |
+| `serviceLevelAgreementUrl` | string \| null | SLA URL |
+| `dataProcessingAgreementUrl` | string \| null | DPA URL |
+| `businessAssociateAgreementUrl` | string \| null | BAA URL |
+| `subprocessorsListUrl` | string \| null | Subprocessors list URL |
+| `certifications` | string[] | List of certifications |
+| `countries` | string[] | Country codes where vendor operates |
+| `securityPageUrl` | string \| null | Security page URL |
+| `trustPageUrl` | string \| null | Trust page URL |
+| `headquarterAddress` | string \| null | Headquarters address |
+| `legalName` | string \| null | Legal entity name |
+| `websiteUrl` | string \| null | Website URL |
+| `businessOwnerId` | string \| null | Business owner user ID |
+| `securityOwnerId` | string \| null | Security owner user ID |
+| `createdAt` | string | Creation timestamp (RFC 3339) |
+| `updatedAt` | string | Last update timestamp (RFC 3339) |
+
+### User
+
+Sent for `user:created`, `user:updated`, and `user:deleted` events.
+
+```json
+{
+  "id": "usr_01GHI789",
+  "organizationId": "org_01MNO345",
+  "emailAddress": "jane@example.com",
+  "fullName": "Jane Doe",
+  "kind": "EMPLOYEE",
+  "source": "MANUAL",
+  "state": "ACTIVE",
+  "additionalEmailAddresses": ["jane.doe@example.com"],
+  "position": "Security Engineer",
+  "contractStartDate": "2024-01-15T00:00:00Z",
+  "contractEndDate": null,
+  "createdAt": "2024-01-15T09:00:00Z",
+  "updatedAt": "2025-02-01T11:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | User identifier |
+| `organizationId` | string | Organization identifier |
+| `emailAddress` | string | Primary email address |
+| `fullName` | string | Full name |
+| `kind` | string \| null | User kind (e.g. `EMPLOYEE`) |
+| `source` | string | Profile source (e.g. `MANUAL`) |
+| `state` | string | Profile state (e.g. `ACTIVE`) |
+| `additionalEmailAddresses` | string[] | Additional email addresses |
+| `position` | string \| null | Job position |
+| `contractStartDate` | string \| null | Contract start date (RFC 3339) |
+| `contractEndDate` | string \| null | Contract end date (RFC 3339) |
+| `createdAt` | string | Creation timestamp (RFC 3339) |
+| `updatedAt` | string | Last update timestamp (RFC 3339) |
+
+### Obligation
+
+Sent for `obligation:created`, `obligation:updated`, and `obligation:deleted` events.
+
+```json
+{
+  "id": "obl_01PQR678",
+  "organizationId": "org_01MNO345",
+  "area": "Data Protection",
+  "source": "GDPR",
+  "requirement": "Maintain records of processing activities",
+  "actionsToBeImplemented": "Implement ROPA template and quarterly review",
+  "regulator": "CNIL",
+  "ownerId": "usr_01GHI789",
+  "lastReviewDate": "2025-01-01T00:00:00Z",
+  "dueDate": "2025-06-30T00:00:00Z",
+  "status": "IN_PROGRESS",
+  "type": "LEGAL",
+  "createdAt": "2024-06-01T10:00:00Z",
+  "updatedAt": "2025-01-15T14:00:00Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Obligation identifier |
+| `organizationId` | string | Organization identifier |
+| `area` | string \| null | Compliance area |
+| `source` | string \| null | Regulatory source |
+| `requirement` | string \| null | Requirement description |
+| `actionsToBeImplemented` | string \| null | Required actions |
+| `regulator` | string \| null | Regulatory body |
+| `ownerId` | string | Owner user ID |
+| `lastReviewDate` | string \| null | Last review date (RFC 3339) |
+| `dueDate` | string \| null | Due date (RFC 3339) |
+| `status` | string | Obligation status |
+| `type` | string | Obligation type |
+| `createdAt` | string | Creation timestamp (RFC 3339) |
+| `updatedAt` | string | Last update timestamp (RFC 3339) |

--- a/src/content/docs/docs/api/webhooks/overview.mdx
+++ b/src/content/docs/docs/api/webhooks/overview.mdx
@@ -1,0 +1,99 @@
+---
+title: Webhooks Overview
+description: Receive real-time notifications when events happen in Probo
+---
+
+Webhooks allow you to receive HTTP notifications when events occur in your Probo organization. When a subscribed event happens, Probo sends a `POST` request to your configured endpoint with details about the event.
+
+## How it works
+
+import { Steps } from '@astrojs/starlight/components';
+
+<Steps>
+
+1. **Create a webhook subscription**
+
+   Configure an endpoint URL and select which events you want to receive, either from the Probo console under **Settings > Webhooks** or using the [CLI](/docs/cli/commands/webhooks).
+
+2. **Receive events**
+
+   When a subscribed event occurs, Probo sends a signed `POST` request to your endpoint with a JSON payload describing the event.
+
+3. **Verify and process**
+
+   Verify the request signature using your signing secret, then process the event data.
+
+</Steps>
+
+## Endpoint requirements
+
+- Must use **HTTPS**
+- Must respond with a `2xx` status code (`200`, `201`, `202`, or `204`)
+- Must respond within **30 seconds**
+
+Responses with any other status code or timeouts are marked as failed.
+
+## Payload format
+
+Every webhook delivery sends a JSON body with this structure:
+
+```json
+{
+  "eventId": "whevt_01ABC123",
+  "subscriptionId": "whsub_01DEF456",
+  "organizationId": "org_01GHI789",
+  "eventType": "vendor:created",
+  "createdAt": "2025-01-15T10:30:00Z",
+  "data": {
+    // Event-specific fields
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `eventId` | Unique identifier for this webhook event |
+| `subscriptionId` | The subscription that triggered this delivery |
+| `organizationId` | The organization where the event occurred |
+| `eventType` | The type of event (e.g. `vendor:created`) |
+| `createdAt` | When the event was created (RFC 3339) |
+| `data` | Event-specific payload (see [Event Types](/docs/api/webhooks/event-types)) |
+
+## HTTP headers
+
+Each webhook request includes the following headers:
+
+| Header | Description |
+|--------|-------------|
+| `Content-Type` | `application/json` |
+| `X-Probo-Webhook-Event` | The event type (e.g. `vendor:created`) |
+| `X-Probo-Webhook-Organization-Id` | The organization ID |
+| `X-Probo-Webhook-Timestamp` | Unix timestamp (seconds) of the request |
+| `X-Probo-Webhook-Signature` | HMAC-SHA256 hex signature for verification |
+
+## Signing secret
+
+When you create a webhook subscription, Probo generates a signing secret (prefixed with `whsec_`). You can view this secret in the console or retrieve it via the CLI. Store it securely — you'll need it to [verify webhook signatures](/docs/api/webhooks/signature-verification).
+
+## Delivery behavior
+
+- Events are processed in order, with a polling interval of approximately 5 seconds.
+- Failed deliveries are **not retried**. The response status code, headers, and body (up to 64 KB) are stored and visible in the console for debugging.
+- Delivery history is available in **Settings > Webhooks** in the Probo console.
+
+## Next steps
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <LinkCard
+    title="Event Types"
+    description="See all available webhook events and their payloads"
+    href="/docs/api/webhooks/event-types"
+  />
+  <LinkCard
+    title="Signature Verification"
+    description="Verify that webhook requests come from Probo"
+    href="/docs/api/webhooks/signature-verification"
+  />
+</CardGrid>

--- a/src/content/docs/docs/api/webhooks/signature-verification.mdx
+++ b/src/content/docs/docs/api/webhooks/signature-verification.mdx
@@ -1,0 +1,150 @@
+---
+title: Signature Verification
+description: Verify that webhook requests are genuinely from Probo
+---
+
+Every webhook request from Probo includes a cryptographic signature that you should verify to ensure the request is authentic and hasn't been tampered with.
+
+## How it works
+
+Probo signs each webhook payload using **HMAC-SHA256** with the signing secret from your webhook subscription. The signature is sent in the `X-Probo-Webhook-Signature` header.
+
+The signed message is the concatenation of the timestamp and the raw request body, separated by a colon:
+
+```
+{timestamp}:{body}
+```
+
+Where:
+- `timestamp` is the value of the `X-Probo-Webhook-Timestamp` header (Unix seconds)
+- `body` is the raw JSON request body
+
+## Verification steps
+
+import { Steps } from '@astrojs/starlight/components';
+
+<Steps>
+
+1. **Extract the headers**
+
+   Read `X-Probo-Webhook-Timestamp` and `X-Probo-Webhook-Signature` from the request.
+
+2. **Build the signed message**
+
+   Concatenate the timestamp, a colon (`:`), and the raw request body.
+
+3. **Compute the expected signature**
+
+   Calculate `HMAC-SHA256` using your signing secret (without the `whsec_` prefix) as the key and the signed message as the input. Hex-encode the result.
+
+4. **Compare signatures**
+
+   Use a constant-time comparison to check if the computed signature matches the `X-Probo-Webhook-Signature` header.
+
+</Steps>
+
+## Examples
+
+### Go
+
+```go
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func verifyWebhook(r *http.Request, signingSecret string) ([]byte, error) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := r.Header.Get("X-Probo-Webhook-Timestamp")
+	signature := r.Header.Get("X-Probo-Webhook-Signature")
+
+	// Remove the whsec_ prefix
+	secret := strings.TrimPrefix(signingSecret, "whsec_")
+	secretBytes, err := hex.DecodeString(secret)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the signed message
+	message := fmt.Sprintf("%s:%s", timestamp, string(body))
+
+	// Compute HMAC-SHA256
+	mac := hmac.New(sha256.New, secretBytes)
+	mac.Write([]byte(message))
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	// Constant-time comparison
+	if !hmac.Equal([]byte(expected), []byte(signature)) {
+		return nil, fmt.Errorf("invalid signature")
+	}
+
+	return body, nil
+}
+```
+
+### Python
+
+```python
+import hashlib
+import hmac
+from binascii import unhexlify
+
+def verify_webhook(body: bytes, timestamp: str, signature: str, signing_secret: str) -> bool:
+    # Remove the whsec_ prefix
+    secret = signing_secret.removeprefix("whsec_")
+    secret_bytes = unhexlify(secret)
+
+    # Build the signed message
+    message = f"{timestamp}:{body.decode()}"
+
+    # Compute HMAC-SHA256
+    expected = hmac.new(
+        secret_bytes,
+        message.encode(),
+        hashlib.sha256,
+    ).hexdigest()
+
+    # Constant-time comparison
+    return hmac.compare_digest(expected, signature)
+```
+
+### Node.js
+
+```javascript
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+function verifyWebhook(body, timestamp, signature, signingSecret) {
+  // Remove the whsec_ prefix
+  const secret = signingSecret.replace("whsec_", "");
+  const secretBytes = Buffer.from(secret, "hex");
+
+  // Build the signed message
+  const message = `${timestamp}:${body}`;
+
+  // Compute HMAC-SHA256
+  const expected = createHmac("sha256", secretBytes)
+    .update(message)
+    .digest("hex");
+
+  // Constant-time comparison
+  return timingSafeEqual(Buffer.from(expected), Buffer.from(signature));
+}
+```
+
+## Security recommendations
+
+- **Always verify signatures** in production. Never skip verification, even in development.
+- **Use constant-time comparison** to prevent timing attacks. All examples above use the appropriate function for this.
+- **Validate the timestamp** to prevent replay attacks. Reject requests where the timestamp is more than 5 minutes old.
+- **Store signing secrets securely** using environment variables or a secret manager. Never commit them to source control.

--- a/src/content/docs/docs/product/scim/google-workspace.mdx
+++ b/src/content/docs/docs/product/scim/google-workspace.mdx
@@ -1,0 +1,166 @@
+---
+title: Google Workspace SCIM Bridge
+description: Configure automated user provisioning from Google Workspace using the Probo Bridge
+---
+
+This guide walks you through setting up the Probo Bridge to automatically synchronize users from Google Workspace into Probo via SCIM.
+
+## Prerequisites
+
+- Google Workspace administrator access (to create OAuth credentials)
+- Probo organization administrator access
+- A Google Cloud project with the Admin SDK API enabled
+
+## How It Works
+
+The Google Workspace Bridge connects to Google's Admin Directory API using OAuth2, retrieves your organization's user directory, and synchronizes it with Probo through the SCIM endpoint. The Bridge runs on a regular schedule and handles:
+
+- **New users**: Creates Probo accounts for users found in Google Workspace
+- **Updated users**: Syncs attribute changes (name, title, department, etc.)
+- **Removed users**: Deactivates Probo accounts for users no longer in Google Workspace
+- **Excluded users**: Skips users you've explicitly excluded by email
+
+### Mapped Attributes
+
+| Google Workspace Field | SCIM Attribute |
+|----------------------|----------------|
+| Primary email | `userName`, `emails` |
+| Display name | `displayName` |
+| First name | `name.givenName` |
+| Last name | `name.familyName` |
+| Suspended status | `active` |
+| Job title | `title` |
+| Department | `enterprise:department` |
+| Cost center | `enterprise:costCenter` |
+| Employee ID | `enterprise:employeeNumber` |
+| Manager email | `enterprise:manager` |
+| Language | `preferredLanguage` |
+
+import { Steps } from '@astrojs/starlight/components';
+
+## Step 1: Create Google OAuth Credentials
+
+<Steps>
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/)
+2. Select or create a project for Probo integration
+3. Go to **APIs & Services** > **Enabled APIs & Services**
+4. Click **+ Enable APIs and Services** and enable the **Admin SDK API**
+5. Go to **APIs & Services** > **Credentials**
+6. Click **+ Create Credentials** > **OAuth client ID**
+7. Configure the OAuth consent screen if prompted:
+
+   | Field | Value |
+   |-------|-------|
+   | **App name** | `Probo SCIM Bridge` |
+   | **User support email** | Your admin email |
+   | **Scopes** | `https://www.googleapis.com/auth/admin.directory.user.readonly` |
+
+8. Create the OAuth client ID:
+
+   | Field | Value |
+   |-------|-------|
+   | **Application type** | `Web application` |
+   | **Name** | `Probo SCIM Bridge` |
+   | **Authorized redirect URIs** | `https://your-probo-domain.com/connect/google/callback` |
+
+9. Save the **Client ID** and **Client Secret**
+
+</Steps>
+
+## Step 2: Configure the Bridge in Probo
+
+<Steps>
+
+1. Log in to Probo as an organization administrator
+2. Go to **Organization Settings** > **Authentication** > **Auto-Provisioning**
+3. Click **Add Connector** and select **Google Workspace**
+4. Enter your OAuth credentials:
+
+   | Field | Value |
+   |-------|-------|
+   | **Client ID** | Your Google OAuth Client ID |
+   | **Client Secret** | Your Google OAuth Client Secret |
+
+5. Click **Authorize** to complete the OAuth flow — you'll be redirected to Google to grant access
+6. After authorization, the Bridge connector will appear as **Pending**
+
+</Steps>
+
+## Step 3: Configure Exclusions (Optional)
+
+If you have service accounts, shared mailboxes, or other users that should not be provisioned into Probo:
+
+<Steps>
+
+1. In the Bridge connector settings, go to **Excluded Users**
+2. Add email addresses of users to exclude (case-insensitive)
+3. Click **Save**
+
+</Steps>
+
+Excluded users will be skipped during synchronization. If an excluded user was previously provisioned, they will be removed on the next sync cycle.
+
+## Step 4: Verify Synchronization
+
+After the Bridge is configured, it will begin synchronizing on its regular schedule (approximately every 30 seconds for polling, with a 5-minute sync timeout).
+
+<Steps>
+
+1. Go to **Organization Settings** > **Authentication** > **Auto-Provisioning**
+2. Check the Bridge state — it should transition from **Pending** to **Syncing** and then to **Active**
+3. Go to **Organization Settings** > **Members** to verify users have been provisioned
+4. Check the **Event Log** for detailed sync activity
+
+</Steps>
+
+## Troubleshooting
+
+### Bridge Stuck in "Pending"
+
+- **Cause**: OAuth authorization was not completed or the token has expired
+- **Solution**: Re-authorize the Google Workspace connector by clicking **Authorize** again
+
+### Bridge in "Failed" State
+
+- **Cause**: The sync encountered an error (network issue, API rate limit, invalid credentials)
+- **Solution**: Check the Event Log for error details. The Bridge will automatically retry with exponential backoff. If the issue persists after 10 consecutive failures, the Bridge will be disabled — fix the underlying issue and re-enable it manually.
+
+### Users Not Appearing
+
+- **Cause**: The Google OAuth scope may not include directory access, or users are in an organizational unit not visible to the admin account
+- **Solution**: Verify the Admin SDK API is enabled and the OAuth consent screen includes the `admin.directory.user.readonly` scope
+
+### Stale Users Not Deactivated
+
+- **Cause**: Users may be in the exclusion list, or the sync hasn't completed a full cycle yet
+- **Solution**: Check the exclusion list and wait for the next sync cycle. Each sync processes up to 500 users per page from Google Workspace.
+
+### OAuth Token Expired
+
+- **Cause**: The refresh token has been revoked or expired
+- **Solution**: Re-authorize the connector. The Bridge automatically refreshes OAuth tokens, but if the refresh token itself is revoked (e.g., user removed app access in Google), you'll need to re-authorize.
+
+## Combining with SSO
+
+For the best experience, combine SCIM Bridge provisioning with SAML SSO:
+
+1. **SCIM Bridge** handles user lifecycle — creating and deactivating accounts automatically
+2. **SAML SSO** handles authentication — users sign in with their Google credentials
+
+This means users get automatic Probo accounts when they join your organization and lose access when they leave, with no manual account management needed.
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <LinkCard
+    title="Google Workspace SSO"
+    description="Set up SAML SSO alongside SCIM provisioning"
+    href="/docs/product/sso/google-workspace"
+  />
+  <LinkCard
+    title="SCIM Overview"
+    description="Learn more about SCIM features and direct provisioning"
+    href="/docs/product/scim/overview"
+  />
+</CardGrid>

--- a/src/content/docs/docs/product/scim/overview.mdx
+++ b/src/content/docs/docs/product/scim/overview.mdx
@@ -1,0 +1,159 @@
+---
+title: SCIM Overview
+description: Automated user provisioning and deprovisioning with SCIM 2.0 and Bridge sync
+---
+
+Probo supports SCIM 2.0 (System for Cross-domain Identity Management) for automated user provisioning. Combined with the Bridge sync system, Probo can automatically create, update, deactivate, and remove user accounts based on your identity provider's directory.
+
+## How It Works
+
+Probo's SCIM implementation has two modes:
+
+### Direct SCIM Provisioning
+
+Your identity provider pushes user changes to Probo's SCIM endpoint in real time. This is the standard SCIM 2.0 flow — your IdP calls Probo whenever a user is created, updated, or removed.
+
+### Bridge Sync
+
+The Bridge is Probo's built-in synchronization engine that periodically pulls user data from your identity provider and reconciles it with Probo. This is useful for identity providers that don't support outbound SCIM push, or when you want Probo to be the driver of synchronization.
+
+The Bridge:
+- Polls your identity provider at regular intervals
+- Creates users found in the provider but missing from Probo
+- Updates users when attributes have changed
+- Deactivates users present in Probo but removed from the provider
+- Supports excluding specific users from synchronization
+
+## Supported Identity Providers
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <LinkCard
+    title="Google Workspace"
+    description="Sync users from Google Workspace via Bridge"
+    href="/docs/product/scim/google-workspace"
+  />
+</CardGrid>
+
+**Direct SCIM provisioning** works with any SCIM 2.0 compliant identity provider:
+- Okta
+- Azure Active Directory (Entra ID)
+- OneLogin
+- JumpCloud
+- Any SCIM 2.0 client
+
+## SCIM Endpoint
+
+The SCIM 2.0 API is available at:
+
+```
+https://your-probo-domain.com/api/connect/v1/scim/2.0/Users
+```
+
+### Supported Operations
+
+| Operation | Method | Endpoint | Description |
+|-----------|--------|----------|-------------|
+| **Create** | `POST` | `/Users` | Provision a new user |
+| **Get** | `GET` | `/Users/{id}` | Retrieve a specific user |
+| **List** | `GET` | `/Users` | List users with pagination |
+| **Replace** | `PUT` | `/Users/{id}` | Full user replacement |
+| **Update** | `PATCH` | `/Users/{id}` | Partial user update |
+| **Delete** | `DELETE` | `/Users/{id}` | Remove a user |
+
+### Authentication
+
+All SCIM requests require a Bearer token:
+
+```bash
+curl -H "Authorization: Bearer <scim-token>" \
+     -H "Content-Type: application/scim+json" \
+     https://your-probo-domain.com/api/connect/v1/scim/2.0/Users
+```
+
+The token is generated when you create a SCIM configuration in Probo.
+
+### Supported Schemas
+
+Probo supports the following SCIM schemas:
+
+- **Core User Schema** (`urn:ietf:params:scim:schemas:core:2.0:User`) — username, displayName, name, emails, phoneNumbers, active status, title
+- **Enterprise User Extension** (`urn:ietf:params:scim:schemas:extension:enterprise:2.0:User`) — employeeNumber, costCenter, organization, division, department, manager
+
+### Filtering
+
+The SCIM endpoint supports filtering with the `eq` (equality) operator:
+
+```
+GET /Users?filter=userName eq "john@example.com"
+GET /Users?filter=externalId eq "12345"
+```
+
+## Setting Up SCIM
+
+import { Steps } from '@astrojs/starlight/components';
+
+<Steps>
+
+1. **Create a SCIM configuration**
+
+   In Probo, go to **Organization Settings** > **Authentication** > **Auto-Provisioning** and create a new SCIM configuration. This generates your SCIM endpoint URL and bearer token.
+
+2. **Save the token**
+
+   The bearer token is shown only once. Copy and store it securely.
+
+3. **Configure your identity provider**
+
+   Enter the SCIM endpoint URL and bearer token in your IdP's provisioning settings, or set up a Bridge connector for pull-based sync.
+
+4. **Test the connection**
+
+   Verify provisioning works by assigning a test user in your IdP and confirming the account appears in Probo.
+
+</Steps>
+
+## Bridge Sync States
+
+When using Bridge sync, each bridge goes through the following lifecycle:
+
+| State | Description |
+|-------|-------------|
+| **Pending** | Initial state after creation |
+| **Syncing** | Synchronization in progress |
+| **Active** | Last sync completed successfully |
+| **Failed** | Sync failed, will retry with exponential backoff |
+| **Disabled** | Permanently disabled after 10 consecutive failures |
+
+The Bridge uses exponential backoff for retries, with a maximum backoff of 24 hours. If a bridge fails 10 times consecutively, it is automatically disabled and requires manual re-enablement.
+
+## Excluding Users
+
+You can exclude specific users from Bridge synchronization by email address. Excluded users in your identity provider will not be provisioned into Probo. This is useful for service accounts, shared mailboxes, or other non-human identities that shouldn't have Probo accounts.
+
+## Audit Logging
+
+All SCIM API interactions are logged with:
+- HTTP method and path
+- Response status code
+- Request and response bodies
+- Source IP address
+- Associated user (when applicable)
+
+View SCIM events in **Organization Settings** > **Authentication** > **Auto-Provisioning** > **Event Log**.
+
+## Next Steps
+
+<CardGrid>
+  <LinkCard
+    title="Google Workspace Bridge"
+    description="Set up automated user sync from Google Workspace"
+    href="/docs/product/scim/google-workspace"
+  />
+  <LinkCard
+    title="SSO Overview"
+    description="Combine SCIM provisioning with SAML Single Sign-On"
+    href="/docs/product/sso/overview"
+  />
+</CardGrid>


### PR DESCRIPTION
Simplifies the documentation sidebar navigation by promoting commonly-used sections to top-level items. SSO and SCIM are now directly accessible under Product, while MCP, n8n, and Webhooks are top-level under Integrations. Removes NEW badges from these sections and collapses nested tool and integration lists by default for cleaner navigation.