### PR TITLE
Add open letter to AICPA and ISO accreditation bodies

### DIFF
--- a/src/content/blog/2026-03-20-an-open-letter-to-aicpa-and-iso-accreditation-bodies.mdx
+++ b/src/content/blog/2026-03-20-an-open-letter-to-aicpa-and-iso-accreditation-bodies.mdx
@@ -1,0 +1,63 @@
+---
+title: "An Open Letter to AICPA and ISO Accreditation Bodies"
+date: 2026-03-20
+excerpt: "A compliance automation platform got caught producing near-identical SOC 2 reports for multiple companies. The reports looked real. The security controls behind them were never properly verified. This is an open letter to the organizations responsible for enforcing audit quality."
+author:
+  name: "Bryan Frimin"
+---
+
+A compliance automation platform recently got caught producing near-identical SOC 2 reports for multiple companies. The reports looked real. The certificates looked real. Whether the security controls behind them actually existed was never properly verified.
+
+An internal spreadsheet was accidentally shared via a public Google Drive link. It showed that the vendor was using templates to mass-produce audit reports. These reports were then signed off by licensed audit firms. Firms whose job is to independently verify that controls are in place, tested, and working.
+
+Based on what was exposed, they weren't verifying much.
+
+This is not news to you. You have received reports about this kind of practice before. Multiple times. From multiple sources.
+
+Nothing changed.
+
+## The vendors are not the main problem
+
+Some compliance vendors cut corners. Others don't. But even the ones that do are operating within what your audit firms allow. That's the part nobody wants to talk about.
+
+Your audit firms hold the license. They carry the legal responsibility. They are the ones who sign the report. When they sign off without verifying, everything downstream is worthless. The vendor that cuts corners and the vendor that does real work end up with the same stamp.
+
+You supervise these audit firms. The AICPA for SOC 2. The accreditation bodies under the International Accreditation Forum for ISO 27001. You have done close to nothing about it.
+
+## Reports get filed. Nothing happens.
+
+Audit firms that produce meaningless reports have been reported to you. Multiple times. By multiple people. The firms keep their licenses. They keep auditing. They keep signing.
+
+AICPA, you have acknowledged "common examination deficiencies" in SOC 2 work. You introduced peer review requirements. But no firm has faced meaningful disciplinary action. No license has been pulled.
+
+On the ISO side, the pattern is the same. Organizations like Oxebridge Quality Resources have documented ISO "certificate mills" for years. Certification bodies that hand out certificates without real audits. Complaints go to accreditation bodies. Accreditation bodies ignore them. The IAF, which is supposed to hold accreditation bodies accountable, does not act.
+
+The result: anyone can get a certificate. The certificate loses its meaning. And companies that do compliance properly are indistinguishable from those that bought a stamp.
+
+## Compliance is not security
+
+There is a widespread confusion in the market: people assume compliance means security. It doesn't.
+
+Compliance means respecting laws and frameworks. Most of those frameworks require security measures, yes. But compliance is about adherence to rules. Security is about actually protecting systems, data, and people.
+
+Real security comes from a genuine willingness inside the company to do the work. No vendor can sell that. No template can produce it. When a company actually implements the controls a framework requires, it will be more secure. That's the whole point. But when your audit process doesn't verify that those controls exist, compliance becomes a label with nothing behind it.
+
+## What we are asking you to do
+
+Investigate complaints. When an audit firm is reported for producing fraudulent or negligent reports, act on it. Not in six months. Now.
+
+Enforce consequences. Pull licenses. Publish sanctions. Right now, rubber-stamping carries no cost. That is why it keeps happening.
+
+Address the conflict of interest. Today, the company being audited selects and pays the auditor. If the auditor is too strict, the company picks someone else next time. The auditor knows this. That is why so many of them choose to be lenient.
+
+Be transparent. Publish the results of your enforcement actions. Let the market see which firms are sanctioned and why.
+
+## Why this matters
+
+Every time you ignore a complaint, the credibility of the entire compliance ecosystem erodes. Companies that invest real effort into compliance get the same certificate as those that didn't. Customers who rely on those certificates to make trust decisions are misled. The frameworks you built to protect people and data become paperwork.
+
+If you don't act, you won't just lose credibility. You'll lose relevance. The market will find other ways to establish trust. Ways that don't include you.
+
+We would rather that not happen. These frameworks, when properly enforced, serve a real purpose. But they only work if the organizations behind them do their job.
+
+We are asking you to do your job.


### PR DESCRIPTION
This post addresses the systemic failures in SOC 2 and ISO 27001 audit enforcement, calling on the AICPA and International Accreditation Forum to investigate complaints, enforce consequences, and address conflicts of interest in the audit process.

The post details how compliance vendors and audit firms have repeatedly rubber-stamped reports without proper verification, and how this undermines the credibility of the entire compliance ecosystem.