### PR TITLE
Fix duplicate image in SSO changelog entry

### DIFF
--- a/src/content/changelog/2026-03-22-google-microsoft-sso.mdx
+++ b/src/content/changelog/2026-03-22-google-microsoft-sso.mdx
@@ -6,8 +6,6 @@ image: "/changelog/2026-03-22-google-microsoft-sso.png"
 tags: ["feature"]
 ---
 
-![Screenshot of the Probo login page showing the "Sign in with Google" and "Sign in with Microsoft" buttons alongside the existing login options.](/changelog/2026-03-22-google-microsoft-sso.png)
-
 You can now sign in to Probo using your Google or Microsoft enterprise account. This works across both the console and the public compliance page.
 
 We intentionally only support enterprise accounts (Google Workspace and Microsoft Entra ID). No personal Gmail or Outlook logins. This keeps your team's access clean and ensures every user is tied to a verified company domain.


### PR DESCRIPTION
Remove the inline markdown image from the Google and Microsoft SSO changelog entry. The image was already rendered via the `image` frontmatter field, causing it to appear twice on the page.