### PR TITLE
Fix transparent header background

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,7 +14,7 @@ type Props = {
 ---
 
 <header
-  class="page-header text-primary data-[scrolled=true]:bg-secondary/80 sticky top-0 z-50 transition-all data-[scrolled=true]:border-b data-[scrolled=true]:backdrop-blur-md"
+  class="page-header text-primary bg-secondary/80 sticky top-0 z-50 transition-all border-b backdrop-blur-md"
 >
   <div class="container mx-auto flex items-center py-3 sm:py-4">
     <a class="mr-auto" href={getLink(Astro, "/")} transition:name="header-logo">


### PR DESCRIPTION
## Summary
- Restore the header's white semi-transparent background (`bg-secondary/80`) with `backdrop-blur-md` and `border-b` so they are always applied, not only on scroll.
- This fixes a regression introduced in 986c706 where the background styles were made conditional on `data-[scrolled=true]`, leaving the header fully transparent by default.

## Test plan
- [ ] Verify the header has a white blurred background on page load (before scrolling)
- [ ] Verify the header remains visible with blur when scrolling down