### PR TITLE
Fix changelog tags for access logs and SSO entries

### DIFF
--- a/src/content/changelog/2026-03-22-access-logs.mdx
+++ b/src/content/changelog/2026-03-22-access-logs.mdx
@@ -3,7 +3,7 @@ title: "Access Logs"
 description: "Full visibility into every action happening in your organization with SIEM-ready audit logs."
 date: 2026-03-22
 image: "/changelog/2026-03-22-access-logs.png"
-tags: ["feature"]
+tags: ["Console"]
 ---
 
 Every action in your organization is now logged and visible in one place. Who signed in, who updated a policy, who invited a new team member, when it happened, and from where.

--- a/src/content/changelog/2026-03-22-google-microsoft-sso.mdx
+++ b/src/content/changelog/2026-03-22-google-microsoft-sso.mdx
@@ -3,7 +3,7 @@ title: "Google and Microsoft SSO"
 description: "Sign in to Probo with your Google or Microsoft enterprise account."
 date: 2026-03-22
 image: "/changelog/2026-03-22-google-microsoft-sso.png"
-tags: ["feature"]
+tags: ["IAM"]
 ---
 
 You can now sign in to Probo using your Google or Microsoft enterprise account. This works across both the console and the public compliance page.


### PR DESCRIPTION
Use product area tags (Console, IAM) instead of the generic "feature" tag for the two latest changelog entries, matching the categorization pattern used by all other entries.