### PR TITLE
Fix PostHog pricing A/B test variant name

### DIFF
--- a/src/components/posthog.astro
+++ b/src/components/posthog.astro
@@ -87,7 +87,7 @@
 
   // A/B test: show pricing link only for "test" variant
   function applyPricingFlag() {
-    var show = posthog.getFeatureFlag("pricing-page") === "test";
+    var show = posthog.getFeatureFlag("pricing-page") === "test-pp";
     document.querySelectorAll("[data-pricing-link]").forEach(function (el) {
       el.style.display = show ? "contents" : "none";
     });


### PR DESCRIPTION
## Summary
- Fix the pricing page A/B test feature flag check to use the correct variant name `test-pp` instead of `test`, matching the PostHog configuration.
- Update footer copyright year to 2025-2026.

## Test plan
- [ ] Verify the pricing link appears for users in the `test-pp` variant
- [ ] Verify the pricing link remains hidden for control variant users