### PR TITLE
Move pricing link after About in nav, show EUR on French page

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -21,10 +21,10 @@ type Props = {
       <Image src={Logo} alt="Logo probo" width={73} height={20} class="block" />
     </a>
     <nav class="hidden sm:flex" transition:name="header-nav">
+      <NavLink href={getLink(Astro, "/about")}>{__("About")}</NavLink>
       <span data-pricing-link style="display:none">
         <NavLink href={getLink(Astro, "/pricing")}>{__("Pricing")}</NavLink>
       </span>
-      <NavLink href={getLink(Astro, "/about")}>{__("About")}</NavLink>
       <NavLink href={getLink(Astro, "/blog")}>{__("Blog")}</NavLink>
       <NavLink href={getLink(Astro, "/stories")}>{__("Stories")}</NavLink>
       <NavLink href="/changelog">{__("Changelog")}</NavLink>

--- a/src/components/block/PricingCards.astro
+++ b/src/components/block/PricingCards.astro
@@ -232,7 +232,7 @@ const enterpriseFeatures = [
             <p
               class="text-foreground text-[40px] leading-none font-medium tracking-[-1px]"
             >
-              $10,000
+              {__("$10,000")}
             </p>
             <div class="text-muted-foreground text-xs leading-[1.3]">
               <p>{__("Starting at")}</p>

--- a/src/content/menu.ts
+++ b/src/content/menu.ts
@@ -5,6 +5,11 @@ export const menuItems = [
     href: "/about",
   },
   {
+    label: "Pricing",
+    description: "Plans and pricing for Probo",
+    href: "/pricing",
+  },
+  {
     label: "Blog",
     description: "The latest news from Probo",
     href: "/blog",
@@ -13,11 +18,6 @@ export const menuItems = [
     label: "Stories",
     description: "Hear from our customers",
     href: "/stories",
-  },
-  {
-    label: "Pricing",
-    description: "Plans and pricing for Probo",
-    href: "/pricing",
   },
   {
     label: "Changelog",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,4 +1,5 @@
 {
+  "$10,000": "10 000 €",
   "About": "À propos",
   "About Probo - Open-Source Compliance Platform": "À propos de Probo — Plateforme de conformité open source",
   "Access documents, trigger workflows, and talk directly with your compliance officer - all without leaving Slack. Support that fits seamlessly into how your team already works.": "Accédez aux documents, lancez des workflows et discutez directement avec votre responsable conformité, sans quitter Slack. Un support qui s'intègre parfaitement à la façon dont votre équipe travaille déjà.",


### PR DESCRIPTION
## Summary
- Reorders the pricing nav link to appear right after "About" in both the header and mobile menu
- Makes the Full Service price ($10,000) localizable via the i18n system
- Adds French translation showing the price as "10 000 €" instead of "$10,000"

## Test plan
- [ ] Verify English pricing page still shows $10,000
- [ ] Verify French pricing page (/fr/pricing) shows 10 000 €
- [ ] Verify nav link order: About, Pricing, Blog, Stories, Changelog, Docs