### PR TITLE
Add blog post on insecure Google Workspace defaults

### DIFF
--- a/src/content/blog/2026-03-26-google-workspace-default-settings-are-insecure.mdx
+++ b/src/content/blog/2026-03-26-google-workspace-default-settings-are-insecure.mdx
@@ -1,0 +1,63 @@
+---
+title: "Google Workspace Default Settings Are Insecure. Here's How to Fix Them."
+date: 2026-03-26
+excerpt: "Google Workspace ships with default settings that leave companies exposed. Here are five settings to fix right now."
+author:
+  name: "Bryan Frimin"
+---
+
+Google Workspace ships with default settings that leave companies exposed. Not in a subtle way. In obvious ways that any security person would flag in five minutes.
+
+This isn't a bug. Google favors frictionless onboarding over secure defaults. The easier it is to sign up and start using everything, the more people adopt their products. That's a reasonable business choice for Google, but it means the security part is left to you.
+
+Here are five settings to fix right now.
+
+## 2FA is not enforced by default
+
+In 2026, two-factor authentication is still optional by default on Google Workspace. Any employee can log in with just a password. One weak password, one phished credential, and someone's in your systems.
+
+Go to **Admin Console → Security → Authentication → 2-Step Verification**. Turn on enforcement for the entire organization, pick a deadline, and after that date nobody logs in without 2FA.
+
+## Google Sign-In with broad scopes is allowed everywhere
+
+By default, employees can use "Sign in with Google" on any third-party app. When someone clicks that button, they often grant the app access to their email, contacts, Drive files, everything. Every employee can hand company data to any SaaS tool without anyone knowing.
+
+That's how shadow IT grows and how data leaks happen. Some of these apps will also ping every collaborator in the organization, so tools nobody approved end up reaching people nobody intended.
+
+Go to **Admin Console → Security → API Controls → Third-party app access**. Block all third-party apps by default. Only allow "Sign in with email", the basic scope that shares nothing beyond the email address. If an employee needs to connect a tool to Drive or anything else, they request it, an admin reviews it, and there's a record of what was approved.
+
+## DKIM, DMARC, and SPF are not enabled by default
+
+Google Workspace doesn't set up DKIM, DMARC, or SPF for your domain. Without these, anyone on the internet can send emails pretending to be you. Clients, partners, employees, they have no way to tell the email is fake. These three protocols exist specifically to prevent email spoofing, and they're not turned on out of the box.
+
+**SPF:** Add a TXT record to your DNS: `v=spf1 include:_spf.google.com ~all`. This tells receiving servers that only Google is allowed to send email for your domain.
+
+**DKIM:** Go to **Admin Console → Apps → Google Workspace → Gmail → Authenticate Email**. Generate the DKIM key and add the TXT record to your DNS.
+
+**DMARC:** Add a TXT record: `v=DMARC1; p=none; rua=mailto:dmarc-reports@yourdomain.com`. Start with `p=none` to monitor, then move to `p=quarantine`, then `p=reject` once everything looks clean.
+
+Cloudflare offers free DMARC monitoring. It shows who's sending email on behalf of your domain. Once the reports are clean, switch to reject and spoofed emails get blocked before they reach anyone.
+
+The whole setup is free and takes about thirty minutes.
+
+## Gmail security settings are too permissive
+
+Gmail has built-in protections against malicious attachments, suspicious links, and spoofing attempts. Most of them are not fully enabled by default.
+
+Go to **Admin Console → Apps → Google Workspace → Gmail → Safety**. Turn on enhanced pre-delivery message scanning, it makes Gmail analyze attachments and links before they reach the inbox. Enable protection against encrypted attachments from untrusted senders, scripts from untrusted senders, and anomalous attachment types. Also turn on the protections against links behind shortened URLs and against links that point to untrusted domains.
+
+These settings exist. They work. They're just sitting there waiting for someone to flip them on.
+
+## Set a session timeout
+
+By default, Google sessions stay alive for a very long time. If someone steals a session cookie, they have access for as long as that session lives.
+
+Go to **Admin Console → Security → Google session control**. A good default is 1 week. If that feels too aggressive, 30 days is the absolute maximum. Re-authenticating once a week takes a few seconds. Leaving sessions open for months is a risk nobody needs to take.
+
+## Wrap up
+
+Most companies assume this stuff works out of the box. It doesn't. And that's what makes it so frustrating, because these are just settings. Not expensive tools, not a security team, not a consulting engagement. Just settings that Google left off.
+
+For a small company, it takes about one hour. For a bigger one, the shadow IT cleanup will take longer because you'll find dozens of apps already connected that nobody remembers approving. That part can be ugly, but that's also why you can't skip it.
+
+Your team won't even notice most of these changes. But your company will be way harder to attack.


### PR DESCRIPTION
Adds a new blog post covering five Google Workspace default settings that leave companies exposed: 2FA enforcement, third-party app access, DKIM/DMARC/SPF, Gmail safety settings, and session timeouts. Each section explains the risk and how to fix it.