### PR TITLE
Fix changelog tag for evidence descriptions entry

### DIFF
--- a/src/content/changelog/2026-03-26-automatic-evidence-descriptions.mdx
+++ b/src/content/changelog/2026-03-26-automatic-evidence-descriptions.mdx
@@ -3,7 +3,7 @@ title: "Automatic Evidence Descriptions"
 description: "Upload evidence and Probo automatically generates a description of what it contains."
 date: 2026-03-26
 image: "/changelog/2026-03-26-automatic-evidence-descriptions.png"
-tags: ["feature"]
+tags: ["Console"]
 ---
 
 Uploading evidence is only half the job. The other half is documenting what each file actually proves. That takes time, especially when you're uploading screenshots and exports in bulk during an audit prep sprint.


### PR DESCRIPTION
Replace the generic "feature" tag with "Console" on the automatic evidence descriptions changelog entry to match the tagging convention used by all other entries.