### PR TITLE
Add RSS feed for blog

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -108,7 +108,18 @@ const hreflangUrls = getHreflangUrls(Astro.url);
     <ClientRouter />
 
     <link rel="sitemap" href="/sitemap-index.xml" />
-    <link rel="alternate" type="application/rss+xml" title="Probo Changelog" href="/changelog.xml" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Probo Changelog"
+      href="/changelog.xml"
+    />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Probo Blog"
+      href="/blog.xml"
+    />
 
     <meta name="description" content={description} />
     <link rel="author" href="https://linkedin.com/in/antoinebouchardy" />

--- a/src/pages/blog.xml.ts
+++ b/src/pages/blog.xml.ts
@@ -1,0 +1,23 @@
+import rss from "@astrojs/rss";
+import type { APIContext } from "astro";
+import { getCollection } from "astro:content";
+import { filterLang } from "../lib/i18n.ts";
+
+export async function GET(context: APIContext) {
+  const posts = (await getCollection("blog", filterLang("en"))).sort(
+    (a, b) => b.data.date.valueOf() - a.data.date.valueOf(),
+  );
+
+  return rss({
+    title: "Probo Blog",
+    description:
+      "Insights on compliance, security, and building trust for startups.",
+    site: context.site!,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      description: post.data.excerpt,
+      pubDate: post.data.date,
+      link: `/blog/${post.id}`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- Add RSS feed endpoint at `/blog.xml` for English blog posts, using the same `@astrojs/rss` pattern as the existing changelog feed
- Add `<link rel="alternate">` tag in the layout head so browsers and feed readers can auto-discover the blog feed