### PR TITLE
Add SCIM provisioning guide for Microsoft 365 (Entra ID)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -163,6 +163,10 @@ export default defineConfig({
               label: "Google Workspace",
               slug: "docs/product/scim/google-workspace",
             },
+            {
+              label: "Microsoft 365 (Entra ID)",
+              slug: "docs/product/scim/microsoft-365",
+            },
           ],
         },
         {

--- a/src/content/docs/docs/product/scim/microsoft-365.mdx
+++ b/src/content/docs/docs/product/scim/microsoft-365.mdx
@@ -1,0 +1,216 @@
+---
+title: Microsoft 365 (Entra ID) SCIM
+description: Configure automated user provisioning from Microsoft 365 using Entra ID SCIM
+---
+
+This guide walks you through setting up direct SCIM provisioning from Microsoft Entra ID (formerly Azure Active Directory) to automatically synchronize users into Probo.
+
+## Prerequisites
+
+- Microsoft Entra ID administrator access (Global Administrator or Application Administrator)
+- Probo organization administrator access
+- A Microsoft 365 subscription with Entra ID P1 or higher (required for automatic provisioning)
+
+## How It Works
+
+Microsoft Entra ID pushes user changes to Probo's SCIM 2.0 endpoint in real time. When you assign users or groups to the Probo enterprise application in Entra ID, it automatically:
+
+- **Creates** Probo accounts for newly assigned users
+- **Updates** user attributes when they change in Entra ID
+- **Deactivates** Probo accounts when users are unassigned or disabled
+- **Deletes** Probo accounts when users are permanently removed (if configured)
+
+### Mapped Attributes
+
+**Core User attributes:**
+
+| Entra ID Field                                  | SCIM Attribute                       | Notes                                                                                            |
+| ----------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| userPrincipalName                               | `userName`                           | Required, unique                                                                                 |
+| displayName                                     | `displayName`                        |                                                                                                  |
+| givenName                                       | `name.givenName`                     |                                                                                                  |
+| surname                                         | `name.familyName`                    |                                                                                                  |
+| ImmutableId                                     | `name.formatted`                     |                                                                                                  |
+| honorificPrefix                                 | `name.honorificPrefix`               |                                                                                                  |
+| honorificSuffix                                 | `name.honorificSuffix`               |                                                                                                  |
+| mailNickname                                    | `nickName`                           |                                                                                                  |
+| accountEnabled                                  | `active`                             |                                                                                                  |
+| mail                                            | `emails[type eq "work"].value`       | Multi-valued                                                                                     |
+| telephoneNumber                                 | `phoneNumbers[type eq "work"].value` | Multi-valued                                                                                     |
+| streetAddress, city, state, postalCode, country | `addresses`                          | Multi-valued, with `streetAddress`, `locality`, `region`, `postalCode`, `country` sub-attributes |
+| jobTitle                                        | `title`                              |                                                                                                  |
+| userType                                        | `userType`                           |                                                                                                  |
+| preferredLanguage                               | `preferredLanguage`                  |                                                                                                  |
+| usageLocation                                   | `locale`                             |                                                                                                  |
+| preferredDataLocation                           | `timezone`                           |                                                                                                  |
+| mysiteUrl                                       | `profileUrl`                         |                                                                                                  |
+
+**Enterprise User Extension attributes:**
+
+| Entra ID Field | SCIM Attribute              |
+| -------------- | --------------------------- |
+| employeeId     | `enterprise:employeeNumber` |
+| companyName    | `enterprise:organization`   |
+| department     | `enterprise:department`     |
+| division       | `enterprise:division`       |
+| costCenter     | `enterprise:costCenter`     |
+| manager        | `enterprise:manager.value`  |
+
+import { Steps } from "@astrojs/starlight/components";
+
+## Step 1: Generate SCIM Credentials in Probo
+
+<Steps>
+
+1. Log in to Probo as an organization administrator
+2. Go to **Organization Settings** > **Authentication** > **Auto-Provisioning**
+3. Click **Add Connector** and select **SCIM**
+4. Copy the **SCIM Endpoint URL** and **Bearer Token**
+
+   :::caution
+   The bearer token is shown only once. Store it securely — you will need it in the next step.
+   :::
+
+</Steps>
+
+## Step 2: Create an Enterprise Application in Entra ID
+
+<Steps>
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com)
+2. Go to **Identity** > **Applications** > **Enterprise applications**
+3. Click **+ New application** > **Create your own application**
+4. Enter the following:
+
+   | Field                           | Value                                                                         |
+   | ------------------------------- | ----------------------------------------------------------------------------- |
+   | **Name**                        | `Probo`                                                                       |
+   | **What are you looking to do?** | `Integrate any other application you don't find in the gallery (Non-gallery)` |
+
+5. Click **Create**
+
+</Steps>
+
+## Step 3: Configure Provisioning
+
+<Steps>
+
+1. In the Probo enterprise application, go to **Provisioning** in the left sidebar
+2. Click **Get started**
+3. Set **Provisioning Mode** to **Automatic**
+4. Under **Admin Credentials**, enter:
+
+   | Field            | Value                                                                                       |
+   | ---------------- | ------------------------------------------------------------------------------------------- |
+   | **Tenant URL**   | Your Probo SCIM endpoint URL (e.g. `https://your-probo-domain.com/api/connect/v1/scim/2.0`) |
+   | **Secret Token** | The bearer token from Step 1                                                                |
+
+5. Click **Test Connection** to verify Entra ID can reach the Probo SCIM endpoint
+6. Click **Save**
+
+</Steps>
+
+## Step 4: Configure Attribute Mappings
+
+The default attribute mappings work for most setups. To review or customize them:
+
+<Steps>
+
+1. In the **Provisioning** page, expand **Mappings**
+2. Click **Provision Microsoft Entra ID Users**
+3. Review the attribute mappings — the defaults map to Probo's supported SCIM attributes
+4. Adjust mappings if needed (e.g. map `employeeId` to `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:employeeNumber`)
+5. Click **Save**
+
+</Steps>
+
+:::tip
+You can remove mappings for attributes you don't use. Only `userName`, `displayName`, and `active` are required by Probo.
+:::
+
+## Step 5: Assign Users and Groups
+
+<Steps>
+
+1. In the Probo enterprise application, go to **Users and groups**
+2. Click **+ Add user/group**
+3. Select the users or groups you want to provision into Probo
+4. Click **Assign**
+
+</Steps>
+
+Only assigned users (or members of assigned groups) will be provisioned. This gives you fine-grained control over who gets a Probo account.
+
+## Step 6: Start Provisioning
+
+<Steps>
+
+1. Go back to **Provisioning**
+2. Set **Provisioning Status** to **On**
+3. Click **Save**
+4. Entra ID will start an initial provisioning cycle — this may take a few minutes depending on the number of users
+
+</Steps>
+
+After the initial cycle, Entra ID runs incremental sync approximately every 40 minutes to push any changes.
+
+## Step 7: Verify Provisioning
+
+<Steps>
+
+1. In Entra ID, go to **Provisioning** > **Provisioning logs** to see the sync activity
+2. In Probo, go to **Organization Settings** > **Members** to verify users have been provisioned
+3. Check **Organization Settings** > **Authentication** > **Auto-Provisioning** > **Event Log** for detailed SCIM events
+
+</Steps>
+
+## Troubleshooting
+
+### Test Connection Fails
+
+- **Cause**: The SCIM endpoint URL or bearer token is incorrect, or a firewall is blocking the connection
+- **Solution**: Verify the endpoint URL includes the full path (ending in `/scim/2.0`). Re-generate the bearer token in Probo if needed. Ensure your network allows outbound HTTPS from Entra ID to your Probo instance.
+
+### Users Not Being Provisioned
+
+- **Cause**: Users or groups are not assigned to the enterprise application, or provisioning is not turned on
+- **Solution**: Check that the users are assigned under **Users and groups** and that **Provisioning Status** is set to **On**
+
+### Provisioning Errors in Logs
+
+- **Cause**: Attribute mapping conflicts or missing required attributes
+- **Solution**: Check the **Provisioning logs** in Entra ID for specific error messages. Ensure `userName` is mapped to a unique, non-empty value (typically `userPrincipalName` or `mail`)
+
+### Users Not Deactivated After Removal
+
+- **Cause**: Entra ID may still be processing the change, or the user was soft-deleted
+- **Solution**: Check the provisioning logs for the deprovisioning event. Entra ID processes changes during the next sync cycle (approximately every 40 minutes). For immediate effect, trigger a manual sync by clicking **Restart provisioning** in the Provisioning page.
+
+### Duplicate Users
+
+- **Cause**: The `userName` in Entra ID doesn't match an existing Probo user's email
+- **Solution**: Ensure the attribute mapped to `userName` matches the email format used in Probo. You may need to adjust the mapping to use `mail` instead of `userPrincipalName`.
+
+## Combining with SSO
+
+For the best experience, combine SCIM provisioning with SAML SSO:
+
+1. **SCIM provisioning** handles user lifecycle — creating and deactivating accounts automatically
+2. **SAML SSO** handles authentication — users sign in with their Microsoft credentials
+
+This means users get automatic Probo accounts when they join your organization and lose access when they leave, with no manual account management needed.
+
+import { LinkCard, CardGrid } from "@astrojs/starlight/components";
+
+<CardGrid>
+  <LinkCard
+    title="SCIM Overview"
+    description="Learn more about SCIM features and direct provisioning"
+    href="/docs/product/scim/overview"
+  />
+  <LinkCard
+    title="SSO Overview"
+    description="Set up SAML SSO alongside SCIM provisioning"
+    href="/docs/product/sso/overview"
+  />
+</CardGrid>

--- a/src/content/docs/docs/product/scim/overview.mdx
+++ b/src/content/docs/docs/product/scim/overview.mdx
@@ -18,6 +18,7 @@ Your identity provider pushes user changes to Probo's SCIM endpoint in real time
 The Bridge is Probo's built-in synchronization engine that periodically pulls user data from your identity provider and reconciles it with Probo. This is useful for identity providers that don't support outbound SCIM push, or when you want Probo to be the driver of synchronization.
 
 The Bridge:
+
 - Polls your identity provider at regular intervals
 - Creates users found in the provider but missing from Probo
 - Updates users when attributes have changed
@@ -26,7 +27,7 @@ The Bridge:
 
 ## Supported Identity Providers
 
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard
@@ -34,9 +35,15 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
     description="Sync users from Google Workspace via Bridge"
     href="/docs/product/scim/google-workspace"
   />
+  <LinkCard
+    title="Microsoft 365 (Entra ID)"
+    description="Direct SCIM provisioning from Microsoft Entra ID"
+    href="/docs/product/scim/microsoft-365"
+  />
 </CardGrid>
 
 **Direct SCIM provisioning** works with any SCIM 2.0 compliant identity provider:
+
 - Okta
 - Azure Active Directory (Entra ID)
 - OneLogin
@@ -53,14 +60,14 @@ https://your-probo-domain.com/api/connect/v1/scim/2.0/Users
 
 ### Supported Operations
 
-| Operation | Method | Endpoint | Description |
-|-----------|--------|----------|-------------|
-| **Create** | `POST` | `/Users` | Provision a new user |
-| **Get** | `GET` | `/Users/{id}` | Retrieve a specific user |
-| **List** | `GET` | `/Users` | List users with pagination |
-| **Replace** | `PUT` | `/Users/{id}` | Full user replacement |
-| **Update** | `PATCH` | `/Users/{id}` | Partial user update |
-| **Delete** | `DELETE` | `/Users/{id}` | Remove a user |
+| Operation   | Method   | Endpoint      | Description                |
+| ----------- | -------- | ------------- | -------------------------- |
+| **Create**  | `POST`   | `/Users`      | Provision a new user       |
+| **Get**     | `GET`    | `/Users/{id}` | Retrieve a specific user   |
+| **List**    | `GET`    | `/Users`      | List users with pagination |
+| **Replace** | `PUT`    | `/Users/{id}` | Full user replacement      |
+| **Update**  | `PATCH`  | `/Users/{id}` | Partial user update        |
+| **Delete**  | `DELETE` | `/Users/{id}` | Remove a user              |
 
 ### Authentication
 
@@ -92,7 +99,7 @@ GET /Users?filter=externalId eq "12345"
 
 ## Setting Up SCIM
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 <Steps>
 
@@ -118,12 +125,12 @@ import { Steps } from '@astrojs/starlight/components';
 
 When using Bridge sync, each bridge goes through the following lifecycle:
 
-| State | Description |
-|-------|-------------|
-| **Pending** | Initial state after creation |
-| **Syncing** | Synchronization in progress |
-| **Active** | Last sync completed successfully |
-| **Failed** | Sync failed, will retry with exponential backoff |
+| State        | Description                                        |
+| ------------ | -------------------------------------------------- |
+| **Pending**  | Initial state after creation                       |
+| **Syncing**  | Synchronization in progress                        |
+| **Active**   | Last sync completed successfully                   |
+| **Failed**   | Sync failed, will retry with exponential backoff   |
 | **Disabled** | Permanently disabled after 10 consecutive failures |
 
 The Bridge uses exponential backoff for retries, with a maximum backoff of 24 hours. If a bridge fails 10 times consecutively, it is automatically disabled and requires manual re-enablement.
@@ -135,6 +142,7 @@ You can exclude specific users from Bridge synchronization by email address. Exc
 ## Audit Logging
 
 All SCIM API interactions are logged with:
+
 - HTTP method and path
 - Response status code
 - Request and response bodies
@@ -150,6 +158,11 @@ View SCIM events in **Organization Settings** > **Authentication** > **Auto-Prov
     title="Google Workspace Bridge"
     description="Set up automated user sync from Google Workspace"
     href="/docs/product/scim/google-workspace"
+  />
+  <LinkCard
+    title="Microsoft 365 (Entra ID)"
+    description="Set up direct SCIM provisioning from Entra ID"
+    href="/docs/product/scim/microsoft-365"
   />
   <LinkCard
     title="SSO Overview"


### PR DESCRIPTION
## Summary
- Adds a new documentation page for configuring SCIM provisioning from Microsoft Entra ID (Azure AD) to Probo, with step-by-step instructions covering enterprise app creation, provisioning setup, attribute mappings, and troubleshooting.
- Full attribute mapping table covering all core user and enterprise extension SCIM attributes supported by Probo.
- Updates the SCIM overview page and sidebar navigation to link to the new guide.