### PR TITLE
Fix careers page 404 on French locale

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,7 +26,7 @@ const menus = [
     label: __("Company"),
     items: [
       { label: __("About"), href: getLink(Astro, "/about") },
-      { label: __("Careers"), href: getLink(Astro, "/careers") },
+      { label: __("Careers"), href: "/careers" },
       { label: __("Brand"), href: getLink(Astro, "/brand") },
       { label: "LinkedIn", href: "https://www.linkedin.com/company/getprobo" },
     ],


### PR DESCRIPTION
## Summary
- The careers page is English-only (`/careers`), but the footer used `getLink()` which generated `/fr/careers` for French users, causing a 404.
- Changed the footer link to a hardcoded `/careers` path so all locales point to the existing English page.

## Test plan
- Visit the site in French locale and verify the careers link in the footer goes to `/careers` (not `/fr/careers`)
- Confirm no 404 when clicking the careers link from any locale