### PR TITLE
Add Forward Deployed Engineer job posting

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -49,9 +49,18 @@ const changelog = defineCollection({
   }),
 });
 
+const jobs = defineCollection({
+  loader: glob({ pattern: "**/*.mdx", base: "./src/content/jobs" }),
+  schema: z.object({
+    title: z.string(),
+    location: z.string(),
+    type: z.string(),
+  }),
+});
+
 const docs = defineCollection({
   loader: docsLoader(),
   schema: docsSchema(),
 });
 
-export const collections = { blog, stories, docs, changelog };
+export const collections = { blog, stories, docs, changelog, jobs };

--- a/src/content/jobs/forward-deployed-engineer.mdx
+++ b/src/content/jobs/forward-deployed-engineer.mdx
@@ -1,0 +1,74 @@
+---
+title: "Forward Deployed Engineer"
+location: "Remote (Global)"
+type: "Full-Time"
+---
+
+## About Probo
+
+Probo is an open-source compliance platform, which went through YC in Spring 25.
+
+Probo's platform is designed to help companies manage their compliance, with any framework. As most companies don't have the time or resources to manage compliance internally, we provide a service to help them do things properly.
+
+We are a small team, fully remote, with offices in Paris and San Francisco.
+
+## The Role
+
+You work directly with our customers: assessing their compliance and security posture, building their compliance program, implementing the right controls in Probo, and getting them through audit. You own the relationship end-to-end.
+
+No management layer. Full autonomy.
+
+## What You'll Do
+
+- **Assess:** Run discovery, map infrastructure and data flows against target frameworks, identify gaps, build a realistic roadmap to compliance.
+- **Build:** Design and implement compliance programs: policies, controls, risk registers, vendor assessments. Tailored to each customer.
+- **Ship through audit:** Prepare evidence, liaise with auditors, drive findings to closure.
+- **Stay close:** Be the person your customers call. Respond fast. Flag risks before they become problems.
+- **Automate:** Use AI tooling and Probo's internal automation to eliminate repetitive work.
+- **Shape Probo:** Your customer interactions feed directly into the product. You help define what we build next.
+
+## What We're Looking For
+
+### Required
+
+- 3+ years of experience in a tech company.
+- Technical background (engineering, security, architecture, or technical support). You can look at a cloud environment and turn it into actionable controls.
+- Hands-on experience with at least one major compliance framework: SOC 2, ISO 27001, GDPR, or HIPAA.
+- You use AI to build automations and eliminate manual work. You don't wait for someone else to do it.
+- Organized. You manage multiple customers simultaneously and nothing falls through.
+- You know when you don't know. You ask for help or guidance so you never stay blocked.
+- Clear communicator. You're equally effective talking to a CTO, an engineer, HR, or an auditor.
+
+### Nice to Have
+
+- Experience in infosec, compliance, or GRC, hands-on, not theoretical.
+- Experience with cloud environments (AWS, GCP, Azure) and SaaS security tooling (MDM, SIEM, SSO/IdP).
+- Relevant certs: CISSP, CISA, ISO 27001 Lead Auditor, CCSP.
+- Early-stage startup experience.
+
+## Why This Role
+
+- You're at the intersection of product and customers. Your work directly shapes what Probo builds next.
+- Work with CTOs, engineers, and security teams across industries. Every customer is a different puzzle.
+- Fully remote, no timezone requirements. We have offices in Paris and San Francisco if you want them, but they're optional.
+- Early-stage [YC company](https://www.ycombinator.com/companies/probo). You'll have outsized impact and grow with the company.
+- No bureaucracy, no hand-offs. You own customer relationships end-to-end. If something needs fixing, you fix it.
+
+## Process
+
+1. **Intro call** (15 min): quick chat to get to know each other.
+2. **Founder call** (30 min): deeper conversation with Antoine, Probo CEO.
+3. **Case study** (~2-3 hours, async): a practical exercise to see how you think and work.
+4. **Team meet**: lunch or video call with the team.
+5. **Reference call / Background check**
+6. **Welcome!**
+
+## Compensation & Benefits
+
+- Competitive salary, adjusted to your local cost of living
+- Equity package
+- Health insurance
+- Flexible PTO
+- Fully remote, no timezone requirements
+
+

--- a/src/pages/careers.astro
+++ b/src/pages/careers.astro
@@ -1,15 +1,11 @@
 ---
+import { getCollection } from "astro:content";
 import Layout from "../layouts/Layout.astro";
 import { getTranslator } from "../lib/i18n.ts";
 
 const __ = await getTranslator(Astro.currentLocale);
 
-const positions: {
-  title: string;
-  type: string;
-  location: string;
-  href: string;
-}[] = [];
+const positions = await getCollection("jobs");
 ---
 
 <Layout
@@ -19,7 +15,7 @@ const positions: {
   )}
 >
   <main>
-    <section class="container my-10 sm:mt-20 sm:mb-30">
+    <section class="mx-auto my-10 max-w-[720px] px-5 sm:mt-20 sm:mb-30">
       <h1 class="text-h2 animate-slide-in mb-3 font-medium">
         {__("Careers")}
       </h1>
@@ -36,18 +32,16 @@ const positions: {
       {
         positions.length > 0 ? (
           <div class="animate-slide-in animation-delay-200 flex flex-col gap-4">
-            <h2 class="text-muted-foreground mb-1">
-              {__("Open positions")}
-            </h2>
+            <h2 class="text-muted-foreground mb-1">{__("Open positions")}</h2>
             {positions.map((position) => (
               <a
-                href={position.href}
+                href={`/careers/${position.id}`}
                 class="border-border-low hover:border-border-mid flex items-center justify-between rounded-lg border p-6 transition-colors"
               >
                 <div>
-                  <h3 class="font-medium">{position.title}</h3>
+                  <h3 class="font-medium">{position.data.title}</h3>
                   <p class="text-muted-foreground text-sm">
-                    {position.location} · {position.type}
+                    {position.data.location} · {position.data.type}
                   </p>
                 </div>
                 <span class="text-muted-foreground">→</span>
@@ -73,6 +67,24 @@ const positions: {
           </div>
         )
       }
+
+      <div
+        class="animate-slide-in animation-delay-300 border-border-low mt-10 rounded-lg border p-10 text-center"
+      >
+        <p class="text-muted-foreground mb-4">
+          {
+            __(
+              "Don't see the right role? We're always looking for talented people.",
+            )
+          }
+        </p>
+        <p>
+          {__("Send us your resume at")}{" "}
+          <a href="mailto:hello@getprobo.com" class="text-primary underline">
+            hello@getprobo.com
+          </a>
+        </p>
+      </div>
     </section>
   </main>
 </Layout>

--- a/src/pages/careers/[id].astro
+++ b/src/pages/careers/[id].astro
@@ -1,0 +1,57 @@
+---
+import { getCollection, render } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import Prose from "../../components/Prose.astro";
+import { getTranslator } from "../../lib/i18n.ts";
+
+const __ = await getTranslator(Astro.currentLocale);
+
+export async function getStaticPaths() {
+  const jobs = await getCollection("jobs");
+  return jobs.map((job) => ({
+    params: { id: job.id },
+    props: { job },
+  }));
+}
+
+const { job } = Astro.props;
+const { Content } = await render(job);
+---
+
+<Layout
+  title={`${job.data.title} - ${__("Probo Careers")}`}
+  description={`${__("Join Probo as a")} ${job.data.title}. ${job.data.location} · ${job.data.type}`}
+>
+  <main>
+    <article class="mx-auto my-10 max-w-[720px] px-5 sm:mt-20 sm:mb-30">
+      <a
+        href="/careers"
+        class="text-muted-foreground hover:text-foreground animate-slide-in mb-8 inline-flex items-center gap-1 text-sm transition-colors"
+      >
+        ← {__("Back to careers")}
+      </a>
+
+      <header class="animate-slide-in animation-delay-100 mb-10">
+        <h1 class="text-h2 mb-3 font-medium">
+          {job.data.title}
+        </h1>
+        <p class="text-muted-foreground">
+          {job.data.location} · {job.data.type}
+        </p>
+      </header>
+
+      <Prose class="animate-slide-in animation-delay-200">
+        <Content />
+      </Prose>
+
+      <div class="animate-slide-in animation-delay-300 mt-12 text-center">
+        <a
+          href={`mailto:hello@getprobo.com?subject=${job.data.title} Application`}
+          class="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex items-center rounded-lg px-6 py-3 font-medium transition-colors"
+        >
+          {__("Apply for this job")}
+        </a>
+      </div>
+    </article>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- Add a `jobs` content collection with schema (title, location, type) for managing job postings as MDX files
- Add the Forward Deployed Engineer job posting as the first entry
- Update the careers page to pull positions from the collection and constrain width to 720px
- Add a dynamic `careers/[id]` page to render individual job postings