### PR TITLE
Add missing links to footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,9 +16,12 @@ const menus = [
     label: __("Resources"),
     items: [
       { label: __("Home"), href: getLink(Astro, "/") },
+      { label: __("Pricing"), href: getLink(Astro, "/pricing") },
       { label: __("Blog"), href: getLink(Astro, "/blog") },
       { label: __("Hub"), href: "/hub" },
       { label: __("Stories"), href: getLink(Astro, "/stories") },
+      { label: __("Changelog"), href: getLink(Astro, "/changelog") },
+      { label: __("Docs"), href: "/docs" },
       { label: "GitHub", href: "https://github.com/getprobo/probo" },
     ],
   },


### PR DESCRIPTION
## Summary
- Adds Pricing, Changelog, and Docs links to the footer's Resources section, matching the links available in the header navigation.

## Test plan
- [ ] Verify footer renders all three new links
- [ ] Verify links point to the correct pages