### PR TITLE
Add internal links across blog, stories, and hub pages

### DIFF
--- a/src/content/blog/2025-02-04-the-case-for-open-source-compliance.mdx
+++ b/src/content/blog/2025-02-04-the-case-for-open-source-compliance.mdx
@@ -12,7 +12,7 @@ In our past experience, my cofounder & I faced a harsh reality with compliance
 tools:
 
 - Basic functionality hidden behind a $10k paywall
-- Rigid, one-size-fits-all solutions that are not tailored to your business
+- Rigid, [one-size-fits-all solutions](/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal) that are not tailored to your business
 - No guidance, leaving you guessing what you actually need to do
 
 That's why we are building Probo.
@@ -20,7 +20,7 @@ That's why we are building Probo.
 ## The Compliance Tool Trap
 
 When building a new product, you're juggling dozens of priorities. Then
-suddenly, a customer asks for SOC 2 report.
+suddenly, a customer asks for a [SOC 2](/blog/2025-10-28-what-is-soc2) report.
 
 1. You will take a 30 minutes sales call to get a price indexed on how desperate
    you are
@@ -52,11 +52,11 @@ Here is our vision of how compliance should work:
   integration is missing, feel free to build it and add it to the product. It
   will save you time in the long run and benefit the whole community.
 
-- **Pay only for actual value-added services, with transparent pricing:** You
+- **Pay only for actual value-added services, with [transparent pricing](/pricing):** You
   should be able to test the product before you buy. Our price will always be
   fair, transparent and predictable.
 
 <br />
 
-If you’re aligned with our vision and would like to contribute, please reach
-out!
+If you’re aligned with our vision and would like to contribute, please [reach
+out](/contact)!

--- a/src/content/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal.mdx
+++ b/src/content/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal.mdx
@@ -10,7 +10,7 @@ ogImage: "/blog/Why_one_size_solution_is_not_ideal.png"
 ---
 
 The compliance industry is obsessed with standardization. Big tech dumps
-millions into compliance, while startups get shoved down the SOC2 (or ISO27001)
+millions into compliance, while startups get shoved down the [SOC 2](/blog/2025-10-28-what-is-soc2) (or [ISO 27001](/blog/2025-10-08-soc2-or-iso27001))
 rabbit hole. Unable to grasp the complexity, most startups cave and play the
 "check all boxes" game.
 
@@ -89,10 +89,10 @@ wastes time and creates false assurance.
 
 Your compliance needs are as unique as your business model. Understand your
 risks first. Build meaningful processes. Don't outsource your thinking to a
-template.
+template. There is a better way -- read about [the case for open-source compliance](/blog/2025-02-04-the-case-for-open-source-compliance).
 
 Remember: compliance isn't about making auditors happy - you can push back: they
 don’t know your company as well as you.
 
 It's about proving to stakeholders that you run your business responsibly, not
-just ticking boxes.
+just ticking boxes. See how real companies have taken this approach in our [customer stories](/stories).

--- a/src/content/blog/2025-03-04-what-is-soc2-cost.mdx
+++ b/src/content/blog/2025-03-04-what-is-soc2-cost.mdx
@@ -15,7 +15,7 @@ You've probably searched "SOC 2 compliance cost" a dozen times already. And ever
 
 Here's the truth that most vendors won't tell you upfront: SOC 2 pricing is deliberately opaque. Auditors quote ranges so wide they're almost meaningless. Compliance platforms bury their real costs behind "contact sales" buttons. And consultants? They benefit from your confusion. The less you know, the more they can charge.
 
-Before we dive into specific numbers, understand this: SOC 2 cost isn't a single line item. It's a combination of audit fees, internal resources, tooling, and ongoing maintenance. The total investment for most growing companies ranges from **$25,000 to $150,000+** for year one, depending on your approach.
+Before we dive into specific numbers, understand this: [SOC 2](/blog/2025-10-28-what-is-soc2) cost isn't a single line item. It's a combination of audit fees, internal resources, tooling, and ongoing maintenance. The total investment for most growing companies ranges from **$25,000 to $150,000+** for year one, depending on your approach.
 
 Here's what you actually need to budget for and where you can avoid unnecessary spending.
 
@@ -32,7 +32,7 @@ Sounds simple. But costs can stack up fast.
 The SOC 2 audit is your official proof of compliance. Costs depend on the scope:
 
 - **Type 1 Audit** – A one-time snapshot of your security controls. Faster, cheaper. (The starting point for companies facing their first enterprise deal with a compliance requirement.)
-- **Type 2 Audit** – Assesses your security over a period (3-12 months). Takes longer, costs more.
+- **Type 2 Audit** – Assesses your security over a period (3-12 months). Takes longer, costs more. See our guide on [how long SOC 2 actually takes](/blog/2025-10-09-how-long-for-soc2) for a detailed timeline.
 
 **Budget:** For a small business, $6,000–$7,000 is a reasonable budget.
 
@@ -78,7 +78,7 @@ Not everything the compliance industry pushes is necessary.
 
 ### **Penetration testing**
 
-SOC 2 doesn't require penetration testing. For early-stage startups, it might not even be useful—your product is still evolving, and security testing makes more sense once it stabilizes.
+[SOC 2 doesn't require penetration testing](/blog/2025-10-19-do-you-need-pen-test-for-soc2). For early-stage startups, it might not even be useful—your product is still evolving, and security testing makes more sense once it stabilizes.
 
 If you do go for it, manual testing is worth it.
 
@@ -114,4 +114,4 @@ SOC 2 compliance doesn't need to cost six figures. With a lean approach, small b
 
 ## **SOC 2 with Probo**
 
-If you want a SOC 2 report **without turning compliance into a second full-time job**, [Probo](https://www.getprobo.com/) is a great fit. You get a **hands-off compliance service** (so your team isn't stuck writing policies, chasing evidence, and managing auditors) paired with an **open-source platform** that keeps everything structured, auditable, and easy to maintain year after year.
+If you want a SOC 2 report **without turning compliance into a second full-time job**, [Probo](https://www.getprobo.com/) is a great fit. You get a [hands-off compliance service](/blog/2025-10-17-what-is-hands-off-compliance) (so your team isn't stuck writing policies, chasing evidence, and managing auditors) paired with an **open-source platform** that keeps everything structured, auditable, and easy to maintain year after year.

--- a/src/content/blog/2025-10-08-soc2-or-iso27001.mdx
+++ b/src/content/blog/2025-10-08-soc2-or-iso27001.mdx
@@ -102,16 +102,16 @@ However, this is where startups can make a critical mistake: they are not interc
 
 **So, which one should you choose?**
 
-- Choose SOC 2 if: Your primary customers and growth plans are in North America.
-- Choose ISO 27001 if: You are targeting international markets or want to prove you have a globally recognized security program.
+- Choose SOC 2 if: Your primary customers and growth plans are in North America. Learn more about [what SOC 2 involves](/blog/2025-10-28-what-is-soc2) and [how long it takes](/blog/2025-10-09-how-long-for-soc2).
+- Choose ISO 27001 if: You are targeting international markets or want to prove you have a globally recognized security program. See our guide on [how long ISO 27001 certification takes](/blog/2025-10-12-how-long-for-iso27001).
 
-Making this choice and then navigating the complexities of either framework can be a significant challenge for a growing startup.
+Making this choice and then navigating the [steps toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance) can be a significant challenge for a growing startup.
 
 That’s why Probo exists: to provide expert guidance on which path is right for your business and then manage the entire compliance journey for you.
 
 **The long term play: What if you need both?**
 
-As you scale, you will likely find that you need both. It is a common journey for successful startups. They often start with SOC 2 to win the North American market and later add ISO 27001 as they expand into Europe and Asia.
+As you scale, you will likely find that you need both. It is a common journey for successful startups. They often start with SOC 2 to win the North American market and later add ISO 27001 as they expand into Europe and Asia. You can see this journey in practice with companies like [Vybe (SOC 2)](/stories/vybe-soc2) and [Ahrefs (ISO 27001)](/stories/ahrefs-iso).
 
 The good news is that the work you do for one can be leveraged for the other. Achieving the second framework is significantly easier than the first because the underlying controls overlap. This is where proper foundations become critical. At Probo, we do not just get you compliant for today. We build a security foundation that makes it easy to grow with it or to add new frameworks as your business grows, saving you time and resources.
 

--- a/src/content/blog/2025-10-09-how-long-for-soc2.mdx
+++ b/src/content/blog/2025-10-09-how-long-for-soc2.mdx
@@ -7,7 +7,7 @@ author:
 ogImage: "/blog/How_long_does_it_takes_to_be_soc2_compliant.png"
 ---
 
-For any small company, the question "How long does it take to get SOC 2 compliant?" is one of the first and most critical hurdles. The answer isn't a simple number; it varies with the size of the organization (it is harder to change the way people work) and the complexity of your technical stack. Understanding the requirements is essential for planning resources, managing prospect and customer expectations, and unlocking the enterprise deals that depend on it. This guide breaks down the traditional SOC 2 timeline into phases so you know exactly what to expect.
+For any small company, the question "How long does it take to get [SOC 2](/blog/2025-10-28-what-is-soc2) compliant?" is one of the first and most critical hurdles. The answer isn't a simple number; it varies with the size of the organization (it is harder to change the way people work) and the complexity of your technical stack. Understanding the requirements is essential for planning resources, managing prospect and customer expectations, and unlocking the enterprise deals that depend on it. This guide breaks down the traditional SOC 2 timeline into phases so you know exactly what to expect.
 
 **Key Takeaways**
 
@@ -20,7 +20,7 @@ The journey to SOC 2 compliance is typically broken down into four distinct phas
 
 **Phase 1: Readiness and remediation (the heavy lifting)** _Timeline: \~1 to 4 months_
 
-This is the foundational stage and the longest part of the process. It's where you do the actual work of becoming compliant before an auditor ever gets involved. This includes scoping, gap analysis, implementing controls, and creating documentation and policies. Even with automation tools, expect readiness to take at least a month of effort - you have to figure out what is relevant for you, implement it and document everything.
+This is the foundational stage and the longest part of the process. It's where you do the actual work of becoming compliant before an auditor ever gets involved. This includes scoping, gap analysis, implementing controls, and creating documentation and policies. Even with automation tools, expect readiness to take at least a month of effort - you have to figure out what is relevant for you, implement it and document everything. For a full breakdown of what this phase costs, see [what SOC 2 compliance costs](/blog/2025-03-04-what-is-soc2-cost).
 
 **Phase 2: The audit window (the observation period)** _Timeline: 3 to 12 months (Type II only)_
 
@@ -46,8 +46,8 @@ Here’s how we do it:
 - **We do the heavy lifting for you:** Our expert team acts as your dedicated compliance partner. We create the necessary documents (policies, risk analyses, etc.) to match your ways of working and handle the entire audit process on your behalf (you still need to meet the auditor, it is part of his/her job).
 - **We free up your engineers:** We give your team a practical, prioritized checklist of only the necessary security controls. This means they can stay focused on building your product, not on becoming compliance experts.
 
-Once you are SOC 2, we continue to work with you to run your processes and to help you improve your overall security posture over time - continuous improvement is key!
+Once you are SOC 2, we continue to work with you to run your processes and to help you improve your overall security posture over time - continuous improvement is key! See how [Vybe achieved their SOC 2 report](/stories/vybe-soc2) with Probo.
 
 **Conclusion**
 
-While the traditional path to SOC 2 compliance can be a long and demanding journey, it doesn't have to be that way for your company. Probo’s expert-led, "done-for-you" service was designed to handle the entire process on your behalf. We replace the 3 to 6 months of manual readiness work with a fast, tailored program, ensuring you get SOC 2 will not be a burden. Probo helps you build the foundation of trust and security you need to close bigger deals and grow with confidence.
+While the traditional path to SOC 2 compliance can be a long and demanding journey, it doesn't have to be that way for your company. Probo’s expert-led, [done-for-you service](/blog/2025-10-17-what-is-hands-off-compliance) was designed to handle the entire process on your behalf. We replace the 3 to 6 months of manual readiness work with a fast, tailored program, ensuring you get SOC 2 will not be a burden. Probo helps you build the foundation of trust and security you need to close bigger deals and grow with confidence.

--- a/src/content/blog/2025-10-12-how-long-for-iso27001.mdx
+++ b/src/content/blog/2025-10-12-how-long-for-iso27001.mdx
@@ -16,13 +16,13 @@ faqs:
     answer: "ISO 27001 is not a one-time event. After your initial certification, you will have annual surveillance audits to ensure you are maintaining and continually improving your ISMS."
 ---
 
-Even for small companies, achieving ISO 27001 certification can be a significant project that typically takes between 3 to 8 months. This guide breaks down the timeline into clear phases so you know exactly what to expect.
+Even for small companies, achieving [ISO 27001 certification](/blog/2025-10-08-soc2-or-iso27001) can be a significant project that typically takes between 3 to 8 months. This guide breaks down the timeline into clear phases so you know exactly what to expect.
 
 **Key Takeaways**
 
 - **Expect a 3 to 8-month journey:** For most small to medium-sized businesses, the entire ISO 27001 certification process from start to finish takes about 3 to 8 months.
 - **Size and complexity matter:** The timeline can be shorter (2-4 months) for very small, agile startups with a simple tech stack, but it extend beyond a year for larger or more complex organizations.
-- **It's a phased project:** The process is not a single sprint. It's a structured project with distinct phases, including scoping, risk assessment, implementation, and the final audits.
+- **It's a phased project:** The process is not a single sprint. It's a structured project with [distinct phases toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance), including scoping, risk assessment, implementation, and the final audits.
 
 ## **Breaking down the ISO 27001 timeline**
 
@@ -40,7 +40,7 @@ This is the core of the ISO 27001 process. Your team will conduct a formal risk 
 
 **Phase 3: Implementation (month 2-4)**
 
-This is often the longest and most resource-intensive phase. Here, you put the selected controls and policies into action. This involves everything from writing new security policies and training your staff to implementing technical controls like access management and data encryption.
+This is often the longest and most resource-intensive phase. Here, you put the selected controls and policies into action. This involves everything from writing new security policies and training your staff to implementing technical controls like access management and data encryption. Some organizations also choose to conduct a [penetration test](/blog/2025-10-23-do-you-need-pen-test-for-iso27001) during this phase to validate their technical controls.
 
 **Phase 4: Audits and certification (months 5-6)**
 
@@ -77,7 +77,7 @@ For most startups, the risk assessment and implementation phases (Phases 2 and 3
 
 **3\. Do we need a dedicated person to manage the ISO 27001 project?**
 
-Yes, you will need a dedicated project lead. However, this person doesn't have to be a full-time compliance expert. In small companies, it is usually the CEO or the CTO. Many startups have found success by partnering with a compliance team like us which acts as your dedicated compliance team, managing the project during implementation, streamlining the audit and running your ISMS documentation for you.
+Yes, you will need a dedicated project lead. However, this person doesn't have to be a full-time compliance expert. In small companies, it is usually the CEO or the CTO. Many startups have found success by partnering with a compliance team like us which acts as your dedicated compliance team, managing the project during implementation, streamlining the audit and running your ISMS documentation for you. See how [Lucis achieved their ISO 27001 certification](/stories/lucis-iso) with this approach.
 
 **4\. What happens after we get certified?**
 

--- a/src/content/blog/2025-10-19-do-you-need-pen-test-for-soc2.mdx
+++ b/src/content/blog/2025-10-19-do-you-need-pen-test-for-soc2.mdx
@@ -20,7 +20,7 @@ faqs:
 
 If you're preparing for SOC 2, you've probably asked yourself: “Do we actually need a penetration test?”
 
-It’s a valid question, especially since the SOC 2 framework never explicitly uses the term “penetration test”. What SOC 2 technically requires is that you **identify and remediate security vulnerabilities**, which can be done through either a vulnerability assessment or a penetration test.
+It’s a valid question, especially since the [SOC 2 framework](/blog/2025-10-28-what-is-soc2) never explicitly uses the term “penetration test”. What SOC 2 technically requires is that you **identify and remediate security vulnerabilities**, which can be done through either a vulnerability assessment or a penetration test.
 
 However, in practice, auditors and security-conscious customers expect a penetration test.
 
@@ -91,7 +91,7 @@ In fact, doing a pen test too early can be wasteful:
 - Engineering time is better spent building the product.
 
 **Best practice:**  
-Build your product → implement basic security hygiene → pursue SOC 2 (and pen testing) when a customer or partner explicitly requires it.
+Build your product → implement basic security hygiene → pursue SOC 2 (and pen testing) when a customer or partner explicitly requires it. For a full overview of [the steps toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance), see our dedicated guide.
 
 ### How Probo helps
 
@@ -107,7 +107,7 @@ So you don’t have to manage yet another project.
 ### Conclusion
 
 A penetration test isn’t technically mandatory in SOC 2 but it has become the industry norm and auditor expectation.
-However, if your startup is still early, or no one is asking for it yet, it is perfectly okay to wait.
+However, if your startup is still early, or no one is asking for it yet, it is perfectly okay to wait. If you're also considering ISO 27001, we cover the same question in [do you need a pen test for ISO 27001](/blog/2025-10-23-do-you-need-pen-test-for-iso27001).
 
 ### Frequently asked questions
 
@@ -131,4 +131,4 @@ That’s normal. Auditors don’t expect perfection, just a process. What matter
 - You can show evidence of doing so.
 
 **5. How much does a penetration test cost?**  
-Typically **$2,000 to +$25,000+**, depending on scope, infrastructure complexity, and testing type.
+Typically **$2,000 to +$25,000+**, depending on scope, infrastructure complexity, and testing type. For a broader view of all costs involved, see [what SOC 2 compliance costs](/blog/2025-03-04-what-is-soc2-cost).

--- a/src/content/blog/2025-10-23-do-you-need-pen-test-for-iso27001.mdx
+++ b/src/content/blog/2025-10-23-do-you-need-pen-test-for-iso27001.mdx
@@ -14,14 +14,14 @@ faqs:
     answer: "That's normal and expected. Your auditor will expect to see the pen test report, evidence of remediation plans, and status updates showing fixes or accepted risks. Addressing findings promptly is more important than having a clean report."
 ---
 
-If you are on the path to ISO 27001 certification, you may be wondering: is a penetration test required? The short answer is no - penetration testing is not explicitly mandated by the ISO 27001 standard.
+If you are on the path to [ISO 27001 certification](/blog/2025-10-12-how-long-for-iso27001), you may be wondering: is a penetration test required? The short answer is no - penetration testing is not explicitly mandated by the ISO 27001 standard.
 
 However, it’s expected, especially for tech-driven organizations looking to demonstrate the effectiveness of their security controls.
 
 ### Key takeaways
 
 - Penetration testing is expected, not mandatory: ISO 27001 does not require a penetration test. The framework is risk-based, allowing organizations to choose the controls that best suit their context.
-- Alternatives are acceptable: You can use other methods—like vulnerability scanning, secure code reviews, or architectural assessments to address risk. But pen tests often provide the strongest proof of technical security maturity.
+- Alternatives are acceptable: You can use other methods—like vulnerability scanning, secure code reviews, or architectural assessments—to address risk. But pen tests often provide the strongest proof of technical security maturity. Companies like [Ahrefs](/stories/ahrefs-iso) have successfully navigated this process.
 
 ### Penetration testing in ISO 27001
 
@@ -32,14 +32,14 @@ The heart of an ISMS is the risk assessment: identifying, evaluating, and treati
 A penetration test is one of the most effective and widely accepted controls you can use to meet this requirement. However, it’s not your only option. You can also address technical vulnerabilities using a layered approach:
 
 - Automated vulnerability scanning for your systems and applications
-- Secure code reviews during software development
+- [Secure code reviews](/blog/2025-11-09-do-you-need-code-reviews) during software development
 - Security architecture reviews before launching new infrastructure
 
 The key is this: you must provide evidence that your vulnerability management processes are robust and effective. And for most companies, a penetration test offers the clearest and most compelling proof.
 
 ### Conclusion: Not mandatory, but expected
 
-While penetration testing is not a strict requirement of ISO 27001, it is one of the strongest tools you can use to demonstrate risk management maturity. It should not be just just a checkbox - it is a valuable investment for your company.
+While penetration testing is not a strict requirement of ISO 27001, it is one of the strongest tools you can use to demonstrate risk management maturity. It should not be just just a checkbox - it is a valuable investment for your company. If you are also considering SOC 2, note that [penetration testing expectations for SOC 2](/blog/2025-10-19-do-you-need-pen-test-for-soc2) differ slightly from ISO 27001.
 
 ### Frequently Asked Questions
 

--- a/src/content/blog/2025-10-28-what-is-soc2.mdx
+++ b/src/content/blog/2025-10-28-what-is-soc2.mdx
@@ -21,7 +21,7 @@ For any company, SOC 2 should be a milestone to signals maturity and trustworthi
 However, many founders misunderstand what SOC 2 really is. It’s **not** a certification you hang on a wall, it’s an _attestation report_ issued by an independent auditor.  
 That report is what enterprise customers actually read to determine whether they can trust you with their data.
 
-Understanding what a SOC 2 report includes, and how to get one efficiently, can make the difference between closing deals or wasting your time.
+Understanding what a SOC 2 report includes, and how to get one efficiently, can make the difference between closing deals or wasting your time. If you're wondering about the investment involved, see our breakdown of [SOC 2 compliance costs](/blog/2025-03-04-what-is-soc2-cost).
 
 ## Key takeaways
 
@@ -45,7 +45,7 @@ You’ll also choose between two report types:
 - Type I: a snapshot of controls at a single point in time.
 - Type II: evaluates how those controls operate _over time_ (3 to 12 months).
 
-The choices you make here, what criteria to include and which type to pursue, directly affect how valuable your report will be to customers.
+The choices you make here, what criteria to include and which type to pursue, directly affect how valuable your report will be to customers. For a detailed look at the timeline, read [how long it takes to get SOC 2 compliant](/blog/2025-10-09-how-long-for-soc2).
 
 ## When is it too early to do SOC2? And why that’s okay
 
@@ -66,7 +66,7 @@ Pursuing SOC 2 prematurely can waste time and budget:
 - Your engineers lose focus on product development.
 
 **Best practice:**  
-Focus first on security fundamentals - access control, encryption, backups, and incident response.  
+Focus first on security fundamentals - access control, encryption, backups, and incident response. You might also consider whether [you need a penetration test for SOC 2](/blog/2025-10-19-do-you-need-pen-test-for-soc2) at this stage.
 Then, once enterprise customers start asking about SOC 2, you’ll be ready to move quickly and efficiently.
 
 ## How to get a SOC 2 report
@@ -83,7 +83,7 @@ However, they’re still tools, not services. Someone on your team, often the CT
 - Manage auditor communication
 - Track remediation tasks and timelines
 
-This model saves some manual work but still demands dozens if not hundreds of internal hours and makes a key team member a part-time compliance manager.
+This model saves some manual work but still demands dozens if not hundreds of internal hours and makes a key team member a part-time compliance manager. To understand why this approach has limits, read [why a one-size-fits-all solution like Vanta is not ideal](/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal).
 
 ### 2. A done-for-you service
 

--- a/src/content/blog/2025-11-09-do-you-need-code-reviews.mdx
+++ b/src/content/blog/2025-11-09-do-you-need-code-reviews.mdx
@@ -14,11 +14,11 @@ faqs:
     answer: "Not overly. Simplicity wins. A consistently followed pull request process with approvals is usually enough."
 ---
 
-If you're a company aiming for ISO 27001 certification or a SOC 2 audit, you’ve probably asked yourself whever you needed to implement formal code reviews on every pull request.
+If you’re a company aiming for [ISO 27001 certification](/blog/2025-10-12-how-long-for-iso27001) or a [SOC 2 audit](/blog/2025-10-28-what-is-soc2), you’ve probably asked yourself whever you needed to implement formal code reviews on every pull request.
 
 Both frameworks avoid making direct mandates like “you must perform code reviews”, which creates ambiguity. However, code reviews are one of the clearest, most effective ways to show auditors that your development process is controlled.
 
-Whether you're navigating ISO 27001’s secure coding requirements or SOC 2’s change management criteria, a well-defined code review process can allow you to avoid some scrutiny.
+Whether you’re navigating ISO 27001’s secure coding requirements or SOC 2’s change management criteria, a well-defined code review process can allow you to avoid some scrutiny. If you’re unsure where to begin, check out our guide on [the steps toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance).
 
 ## Key takeaways
 
@@ -61,7 +61,7 @@ From the auditor’s perspective, a code review process demonstrates:
 - Separation of duties: changes are reviewed and approved by someone other than the author.
 - Evidence of control: approvals, comments, and merge histories provide a tamper-evident record of oversight.
 
-A consistent code review process gives auditors confidence that your controls are designed properly and operating effectively.
+A consistent code review process gives auditors confidence that your controls are designed properly and operating effectively. You may also want to understand whether you need a [penetration test for SOC 2](/blog/2025-10-19-do-you-need-pen-test-for-soc2) or [for ISO 27001](/blog/2025-10-23-do-you-need-pen-test-for-iso27001).
 
 ## What can a simple and efficient process look like
 

--- a/src/content/blog/2026-03-26-google-workspace-default-settings-are-insecure.mdx
+++ b/src/content/blog/2026-03-26-google-workspace-default-settings-are-insecure.mdx
@@ -10,7 +10,7 @@ Google Workspace ships with default settings that leave companies exposed. Not i
 
 This isn't a bug. Google favors frictionless onboarding over secure defaults. The easier it is to sign up and start using everything, the more people adopt their products. That's a reasonable business choice for Google, but it means the security part is left to you.
 
-Here are five settings to fix right now.
+Here are five settings to fix right now. If you're working toward [SOC 2](/blog/2025-10-28-what-is-soc2) or [ISO 27001](/blog/2025-10-08-soc2-or-iso27001), every one of these maps to controls your auditor will check.
 
 ## 2FA is not enforced by default
 
@@ -58,6 +58,6 @@ Go to **Admin Console → Security → Google session control**. A good default 
 
 Most companies assume this stuff works out of the box. It doesn't. And that's what makes it so frustrating, because these are just settings. Not expensive tools, not a security team, not a consulting engagement. Just settings that Google left off.
 
-For a small company, it takes about one hour. For a bigger one, the shadow IT cleanup will take longer because you'll find dozens of apps already connected that nobody remembers approving. That part can be ugly, but that's also why you can't skip it.
+For a small company, it takes about one hour. If you need a broader view of [what steps to take toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance), we have a guide for that. For a bigger one, the shadow IT cleanup will take longer because you'll find dozens of apps already connected that nobody remembers approving. That part can be ugly, but that's also why you can't skip it.
 
-Your team won't even notice most of these changes. But your company will be way harder to attack.
+Your team won't even notice most of these changes. But your company will be way harder to attack. For another quick security win, see our [Stripe security checklist](/blog/2026-03-31-stripe-security-101) covering 2FA, SSO, and payout settings.

--- a/src/content/blog/2026-03-31-stripe-security-101.mdx
+++ b/src/content/blog/2026-03-31-stripe-security-101.mdx
@@ -8,7 +8,7 @@ author:
 
 Stripe is probably the most used payment platform in SaaS. And yet most companies I talk to haven't touched their Stripe security settings. The dashboard login is password-only, access is managed by hand, and money just sits there.
 
-If you're going through SOC 2 or ISO 27001, everything below maps directly to controls your auditor will check. But honestly, you should do this regardless.
+If you're going through [SOC 2](/blog/2025-10-28-what-is-soc2) or ISO 27001, everything below maps directly to controls your auditor will check. But honestly, you should do this regardless.
 
 ## Enforce 2FA
 
@@ -26,7 +26,7 @@ Take advantage of it. Without SSO and SCIM, you're managing Stripe access by han
 
 With SCIM, your identity provider handles it. Remove someone from Google Workspace, they're instantly locked out of Stripe. Logged out, access revoked. You can also map roles through SCIM group sync, so permissions stay consistent without anyone touching the Stripe dashboard.
 
-The result: onboarding and offboarding take zero effort on the Stripe side, your access reviews take minutes instead of hours, and your security posture on a critical financial tool goes up significantly. For SOC 2 or ISO 27001, this gives you a clean audit trail for free.
+The result: onboarding and offboarding take zero effort on the Stripe side, your access reviews take minutes instead of hours, and your security posture on a critical financial tool goes up significantly. For SOC 2 or [ISO 27001](/blog/2025-10-12-how-long-for-iso27001), this gives you a clean audit trail for free.
 
 ## Move money off the platform
 
@@ -41,5 +41,7 @@ SOC 2 expects you to manage vendor financial risk (CC9.1, CC9.2). That means ide
 ## Wrapping up
 
 Three settings: 2FA enforcement, SAML/SCIM, automatic payouts. Thirty minutes of work total. All three map to SOC 2 criteria: logical access (CC6.1), risk mitigation (CC9.1/CC9.2). And they're just good practice anyway.
+
+While you're at it, make sure your [Google Workspace defaults are locked down too](/blog/2026-03-26-google-workspace-default-settings-are-insecure). And if you're wondering [how long SOC 2 takes](/blog/2025-10-09-how-long-for-soc2), we have a breakdown.
 
 Stripe holds your money. Treat it like it matters.

--- a/src/content/stories/ahrefs-iso.mdx
+++ b/src/content/stories/ahrefs-iso.mdx
@@ -19,12 +19,12 @@ company:
 
 **The Challenge:** Ahrefs needed to achieve compliance while keep their team velocity and their ways of working.
 
-**The Solution:** Probo’s expert-led services - built on top of Probo’s open-source compliance platform - enabled Ahrefs to achieve ISO 27001 readiness in no time while keeping its teams focused on what mattered.
+**The Solution:** Probo’s expert-led services - built on top of Probo’s [open-source compliance platform](/blog/2025-02-04-the-case-for-open-source-compliance) - enabled Ahrefs to achieve ISO 27001 readiness in no time while keeping its teams focused on what mattered.
 
 **The Results:**
 
 - Audit-ready in weeks, not months, ahead of schedule
-- Six-figure annual savings compared to traditional consulting approaches
+- Six-figure annual savings compared to [traditional consulting approaches](/blog/2025-03-04-what-is-soc2-cost)
 - Minimal internal overhead for engineering and operations teams
 
 ## About Ahrefs
@@ -54,7 +54,7 @@ Ahrefs wanted to:
 
 The core challenge was balancing speed with rigor, ensuring every control, policy, and process was meaningful, efficient, and auditable.
 
-From kickoff to full ISO 27001 certification and SOC 2 report, their ambitious objective was to be ready in 6 months.
+From kickoff to full [ISO 27001](/blog/2025-10-12-how-long-for-iso27001) certification and SOC 2 report, their ambitious objective was to be ready in 6 months.
 
 ## The traditional approach wasn't working
 
@@ -130,7 +130,7 @@ Both teams shared the same principles: move fast, stay rigorous, and avoid unnec
 
 With ISO 27001, Ahrefs continues to work with Probo to build on that foundation.
 
-- SOC 2 Type II observation period in progress
+- [SOC 2 Type II](/blog/2025-10-28-what-is-soc2) observation period in progress
 - Expanding to ISO 42001 (AI governance) and GDPR
 - Continuous improvements, tracked on Probo platform
 

--- a/src/content/stories/blaxel-soc2.mdx
+++ b/src/content/stories/blaxel-soc2.mdx
@@ -55,7 +55,7 @@ But as the company started engaging larger customers, something became clear: be
 
 You need to prove it.
 
-That moment became real when a major opportunity landed on the table. The type of deal you don't want to miss. But it came with detailed security questionnaires, compliance expectations, and formal requirements around SOC 2 and governance.
+That moment became real when a major opportunity landed on the table. The type of deal you don't want to miss. But it came with detailed security questionnaires, compliance expectations, and formal requirements around SOC 2 and governance. Understanding [the steps toward compliance](/blog/2025-09-11-what-are-the-steps-toward-compliance) was critical.
 
 The foundations were there. But they needed formalism.
 
@@ -77,9 +77,9 @@ Through Probo, they worked with a dedicated compliance officer who integrated di
 
 ## SOC 2 First. Then Everything Else.
 
-The first milestone was SOC 2.
+The first milestone was [SOC 2](/blog/2025-10-28-what-is-soc2).
 
-Once that foundation was in place, the rest became structured instead of chaotic. Rather than treating ISO 27001, GDPR, CCPA, and HIPAA as separate initiatives, the work was mapped intelligently. Controls were reused where possible. Real gaps were identified and closed. Redundant work was avoided.
+Once that foundation was in place, the rest became structured instead of chaotic. Rather than treating [ISO 27001](/blog/2025-10-12-how-long-for-iso27001), GDPR, CCPA, and HIPAA as separate initiatives, the work was mapped intelligently. Controls were reused where possible. Real gaps were identified and closed. Redundant work was avoided.
 
 The result wasn't compliance for the sake of badges. It was a coherent trust framework that supported Blaxel's growth.
 

--- a/src/content/stories/lucis-iso.mdx
+++ b/src/content/stories/lucis-iso.mdx
@@ -19,7 +19,7 @@ company:
 
 **The Challenge:** As Lucis expanded rapidly across Europe following their $8.5M seed round, they needed to formalize security practices without slowing down their engineering velocity.
 
-**The Solution:** Probo's expert-led services adapted ISO 27001 to Lucis' actual architecture and workflows, running compliance in the background while the team stayed focused on growth.
+**The Solution:** Probo's expert-led services adapted ISO 27001 to Lucis' actual architecture and workflows, running compliance in the background while the team stayed focused on growth — a true [hands-off compliance](/blog/2025-10-17-what-is-hands-off-compliance) approach.
 
 **The Results:**
 
@@ -51,7 +51,7 @@ As Lucis expanded across **France, the UK, Ireland, and Portugal**, **Baptiste D
 They faced three hard constraints:
 
 - **Extreme data sensitivity**
-  Unlike most B2C products, Lucis manages regulated health data. ISO 27001 wasn't a sales checkbox. It was a signal to users, partners, and regulators that security was foundational.
+  Unlike most B2C products, Lucis manages regulated health data. [ISO 27001](/blog/2025-10-12-how-long-for-iso27001) wasn't a sales checkbox. It was a signal to users, partners, and regulators that security was foundational.
 - **A lean, fast-moving team**
   With engineering focused on shipping product and improving member outcomes, the team couldn't afford months of manual documentation.
 - **Compliance that reflected reality**
@@ -75,7 +75,7 @@ Instead of forcing Lucis into a generic model, Probo mapped ISO 27001 directly o
 
 ### 2. End-to-end execution
 
-From gap analysis to audit preparation, Probo handled the documentation and coordination that typically stalls early-stage teams.
+From gap analysis to [audit preparation](/blog/2025-09-11-what-are-the-steps-toward-compliance), Probo handled the documentation and coordination that typically stalls early-stage teams.
 
 ### 3. Asynchronous, low-friction collaboration
 

--- a/src/content/stories/vybe-soc2.mdx
+++ b/src/content/stories/vybe-soc2.mdx
@@ -56,7 +56,7 @@ To win US customers, and especially to expand toward larger accounts, Vybe neede
 - A structured framework to formalize their security practices
 - A compliance foundation that would scale with them
 
-SOC 2 became an obvious step: a way to formalize what they were already doing right and turn it into a real asset in sales conversations.
+[SOC 2](/blog/2025-10-28-what-is-soc2) became an obvious step: a way to formalize what they were already doing right and turn it into a real asset in sales conversations.
 
 > We're building infrastructure that sits at the heart of our customers' operations. Security and trust can't be optional. We've focused on building a secure product from day one. SOC 2 was a way to formalize that.
 
@@ -64,7 +64,7 @@ SOC 2 became an obvious step: a way to formalize what they were already doing ri
 
 But building, managing, and passing SOC 2 in-house would have been a heavy lift for a small, fast-growing team. They preferred to focus their resources on building their product.
 
-They needed a partner who could guide and support them through the entire SOC 2 lifecycle: from readiness to audit and provide ongoing support and advice when needed.
+They needed a partner who could guide and support them through the entire [SOC 2 lifecycle](/blog/2025-10-09-how-long-for-soc2): from readiness to audit and provide ongoing support and advice when needed.
 
 ## Working with Probo: From Good Practices to Formal Maturity
 
@@ -102,4 +102,4 @@ To do that, trust isn't optional.
 
 By formalizing their security posture early, they've built a foundation that scales with them, supporting their growth in the US and their expansion into Europe.
 
-The Vybe team is now continuing to work on its compliance roadmap with Probo, including GDPR, ensuring that their security standards are properly structured and aligned with the right frameworks, so security never becomes a blocker to growth.
+The Vybe team is now continuing to work on its compliance roadmap with Probo, including GDPR, ensuring that their [security standards are properly structured](/blog/2025-09-11-what-are-the-steps-toward-compliance) and aligned with the right frameworks, so security never becomes a blocker to growth.

--- a/src/pages/hub/iso27001-certification-cost.astro
+++ b/src/pages/hub/iso27001-certification-cost.astro
@@ -564,7 +564,13 @@ const breadcrumbSchema = {
                   __(
                     "ISO 27001 doesn't require penetration testing. For early-stage startups, it might not even be useful—your product is still evolving, and security testing makes more sense once it stabilizes.",
                   )
-                }
+                }{" "}
+                {__("We cover this in detail in")}
+                <a
+                  href="/blog/2025-10-23-do-you-need-pen-test-for-iso27001"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("Do You Need a Pen Test for ISO 27001?")}</a
+                >
               </p>
               <p class="mb-4">
                 {__("If you do go for it, manual testing is worth it.")}
@@ -664,7 +670,14 @@ const breadcrumbSchema = {
                   __(
                     "for features most startups don't need. Open-source alternatives provide core compliance functionality—policy management, control tracking, evidence collection—at a fraction of the cost.",
                   )
-                }
+                }{" "}
+                {__("Read")}
+                <a
+                  href="/blog/2025-02-04-the-case-for-open-source-compliance"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("the case for open-source compliance")}</a
+                >
+                {__("to understand why.")}
               </p>
             </div>
 
@@ -804,8 +817,10 @@ const breadcrumbSchema = {
                 class="text-[#5d770d] hover:underline">Probo</a
               >
               {__("is a great fit. You get a")}
-              <strong class="text-foreground"
-                >{__("hands-off compliance service")}</strong
+              <a
+                href="/blog/2025-10-17-what-is-hands-off-compliance"
+                class="font-semibold text-[#5d770d] hover:underline"
+                >{__("hands-off compliance service")}</a
               >
               {
                 __(
@@ -820,6 +835,19 @@ const breadcrumbSchema = {
                   "that keeps everything structured, auditable, and easy to maintain year after year.",
                 )
               }
+            </p>
+            <p class="mt-4">
+              {__("See how")}
+              <a
+                href="/stories/lucis-iso"
+                class="text-[#5d770d] hover:underline"
+                >{__("Lucis got ISO 27001 certified")}</a
+              >
+              {__("using Probo's managed approach, and explore our")}
+              <a href="/pricing" class="text-[#5d770d] hover:underline"
+                >{__("pricing")}</a
+              >
+              {__("to understand the cost.")}
             </p>
           </div>
         </section>

--- a/src/pages/hub/nis2-tech-teams.astro
+++ b/src/pages/hub/nis2-tech-teams.astro
@@ -447,7 +447,13 @@ const breadcrumbSchema = {
                   __(
                     "This is where NIS2 gets uncomfortable for startups. You're responsible for the security of your entire supply chain, including vendors, contractors, and third-party services.",
                   )
-                }
+                }{" "}
+                {__("For a practical guide, see our article on")}
+                <a
+                  href="/blog/2025-11-09-do-you-need-code-reviews"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("why code reviews matter for compliance")}</a
+                >.
               </p>
               <h4 class="text-foreground mb-2 font-semibold">
                 {__("Technical implementation:")}
@@ -673,7 +679,13 @@ const breadcrumbSchema = {
                   __(
                     "The key word here is \"effectiveness.\" Having controls isn't enough—you need evidence they're working.",
                   )
-                }
+                }{" "}
+                {__("If you're considering penetration testing, read")}
+                <a
+                  href="/blog/2025-10-23-do-you-need-pen-test-for-iso27001"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("whether you need a pen test for ISO 27001")}</a
+                >.
               </p>
             </div>
 
@@ -864,7 +876,13 @@ const breadcrumbSchema = {
                   __(
                     'The "where appropriate" language in the directive shouldn\'t be interpreted loosely. If an account can access sensitive data or systems, MFA is appropriate.',
                   )
-                }
+                }{" "}
+                {__("For a concrete example, see")}
+                <a
+                  href="/blog/2026-03-26-google-workspace-default-settings-are-insecure"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("why Google Workspace default settings are insecure")}</a
+                >.
               </p>
             </div>
           </div>
@@ -1615,6 +1633,23 @@ const breadcrumbSchema = {
                   "The enforcement deadline has passed, and regulators are actively pursuing non-compliant organizations. The question isn't whether to implement NIS2 controls—it's how quickly you can close your compliance gaps.",
                 )
               }
+            </p>
+            <p>
+              {
+                __(
+                  "If NIS2 overlaps with your ISO 27001 or SOC 2 efforts, learn about",
+                )
+              }
+              <a
+                href="/blog/2025-10-08-soc2-or-iso27001"
+                class="text-[#5d770d] hover:underline"
+                >{__("choosing between SOC 2 and ISO 27001")}</a
+              >
+              {__("and explore")}
+              <a href="/pricing" class="text-[#5d770d] hover:underline"
+                >{__("Probo's pricing")}</a
+              >
+              {__("to see how managed compliance can help.")}
             </p>
           </div>
         </section>

--- a/src/pages/hub/third-party-risk-management.astro
+++ b/src/pages/hub/third-party-risk-management.astro
@@ -267,6 +267,12 @@ const breadcrumbSchema = {
                   }
                   <em>{__("your")}</em>
                   {__(" compliance issue.")}
+                  {" "}{__("Learn about the")}
+                  <a
+                    href="/blog/2025-09-11-what-are-the-steps-toward-compliance"
+                    class="text-[#5d770d] hover:underline"
+                    >{__("key steps toward compliance")}</a
+                  >.
                 </p>
               </div>
 
@@ -538,7 +544,13 @@ const breadcrumbSchema = {
                     __(
                       "Manual questionnaires and spreadsheets do not scale. Automation enables consistent assessments, real-time alerts, reassessments, and reporting.",
                     )
-                  }
+                  }{" "}
+                  {__("This is a core advantage of")}
+                  <a
+                    href="/blog/2025-02-04-the-case-for-open-source-compliance"
+                    class="text-[#5d770d] hover:underline"
+                    >{__("open-source compliance platforms")}</a
+                  >.
                 </p>
               </div>
 
@@ -627,6 +639,19 @@ const breadcrumbSchema = {
                 >
               </li>
             </ul>
+            <p class="mt-4">
+              {__("See how companies like")}
+              <a
+                href="/stories/ahrefs-iso"
+                class="text-[#5d770d] hover:underline"
+                >{__("Ahrefs achieved ISO 27001")}</a
+              >
+              {
+                __(
+                  "with Probo, including vendor oversight as part of their certification.",
+                )
+              }
+            </p>
           </div>
         </section>
 

--- a/src/pages/hub/top-compliance-officer-services-2026.astro
+++ b/src/pages/hub/top-compliance-officer-services-2026.astro
@@ -147,7 +147,13 @@ const breadcrumbSchema = {
                 __(
                   "And just like that, compliance goes from a backlog item to an urgent priority. The problem? Most companies waste months chasing the wrong kind of help — buying expensive software tools that still require someone on your team to run them, or hiring consultants who hand over a 200-page gap report and disappear.",
                 )
-              }
+              }{" "}
+              {__("If you're wondering")}
+              <a
+                href="/blog/2025-10-09-how-long-for-soc2"
+                class="text-[#5d770d] hover:underline"
+                >{__("how long SOC 2 actually takes")}</a
+              >{__(", the timeline surprises most founders.")}
             </p>
             <p>
               {
@@ -159,7 +165,7 @@ const breadcrumbSchema = {
             <p>
               {
                 __(
-                  "This list cuts through the noise. No SaaS-only platforms. No \"connect your integrations and figure the rest out yourself.\" Every provider here offers real, hands-on service — the closest thing to having a seasoned compliance officer in-house, without the full-time hire.",
+                  'This list cuts through the noise. No SaaS-only platforms. No "connect your integrations and figure the rest out yourself." Every provider here offers real, hands-on service — the closest thing to having a seasoned compliance officer in-house, without the full-time hire.',
                 )
               }
             </p>
@@ -223,7 +229,7 @@ const breadcrumbSchema = {
               <p class="mb-4">
                 {
                   __(
-                    "Most compliance tools shift the burden to your team under a different name. They automate some evidence collection, but someone still has to configure the platform, review alerts, chase down your team for missing controls, and prep the auditor. That \"someone\" is usually a senior engineer or a founder who has better things to do.",
+                    'Most compliance tools shift the burden to your team under a different name. They automate some evidence collection, but someone still has to configure the platform, review alerts, chase down your team for missing controls, and prep the auditor. That "someone" is usually a senior engineer or a founder who has better things to do.',
                   )
                 }
               </p>
@@ -232,7 +238,13 @@ const breadcrumbSchema = {
                   __(
                     "Probo's model is built around the opposite assumption: you don't want to become a compliance expert. You want the certification so you can close deals and grow. So Probo's team handles your entire compliance journey from start to finish, with your involvement kept minimal by design.",
                   )
-                }
+                }{" "}
+                {__("This is what we call")}
+                <a
+                  href="/blog/2025-10-17-what-is-hands-off-compliance"
+                  class="font-semibold text-[#5d770d] hover:underline"
+                  >{__("hands-off compliance")}</a
+                >.
               </p>
               <p class="mt-4">
                 {
@@ -297,6 +309,20 @@ const breadcrumbSchema = {
                   >
                 </li>
               </ul>
+              <p class="mt-4">
+                {__("See real examples:")}
+                <a
+                  href="/stories/blaxel-soc2"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("Blaxel's SOC 2 journey")}</a
+                >
+                {__("and")}
+                <a
+                  href="/stories/ahrefs-iso"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("Ahrefs' ISO 27001 certification")}</a
+                >.
+              </p>
             </div>
 
             <!-- Frameworks covered -->
@@ -322,7 +348,11 @@ const breadcrumbSchema = {
                 <li>
                   <strong class="text-foreground">{__("Talk to us")}</strong>
                   {" — "}
-                  {__("One onboarding call to understand your stack and processes")}
+                  {
+                    __(
+                      "One onboarding call to understand your stack and processes",
+                    )
+                  }
                 </li>
                 <li>
                   <strong class="text-foreground">{__("We do the work")}</strong
@@ -339,11 +369,7 @@ const breadcrumbSchema = {
                     >{__("You get certified")}</strong
                   >
                   {" — "}
-                  {
-                    __(
-                      "With a credible, accredited auditor and a clean report",
-                    )
-                  }
+                  {__("With a credible, accredited auditor and a clean report")}
                 </li>
                 <li>
                   <strong class="text-foreground"
@@ -365,7 +391,7 @@ const breadcrumbSchema = {
               <p>
                 {
                   __(
-                    '"Compliance shouldn\'t feel like a second job. With Probo, it doesn\'t."',
+                    "\"Compliance shouldn't feel like a second job. With Probo, it doesn't.\"",
                   )
                 }
               </p>
@@ -708,7 +734,9 @@ const breadcrumbSchema = {
               <div class="rounded-lg border border-[#d7edba] bg-[#f0f7e4] p-4">
                 <p>
                   <strong class="text-foreground"
-                    >{__("If you want maximum delegation — choose Probo.")}</strong
+                    >{
+                      __("If you want maximum delegation — choose Probo.")
+                    }</strong
                   >
                   {" "}
                   {
@@ -793,7 +821,13 @@ const breadcrumbSchema = {
                 __(
                   "The difference between a fully managed service and a self-serve tool often adds up to hundreds of hours of engineering time — hours your team could spend building product.",
                 )
-              }
+              }{" "}
+              {__("For a deeper look at the numbers, see")}
+              <a
+                href="/blog/2025-03-04-what-is-soc2-cost"
+                class="text-[#5d770d] hover:underline"
+                >{__("what SOC 2 actually costs")}</a
+              >.
             </p>
           </div>
         </section>

--- a/src/pages/hub/top-grc-tools-2026.astro
+++ b/src/pages/hub/top-grc-tools-2026.astro
@@ -177,6 +177,18 @@ const breadcrumbSchema = {
                 )
               }
             </p>
+            <p>
+              {
+                __(
+                  "If you're just getting started, you may also want to read about",
+                )
+              }
+              <a
+                href="/blog/2025-09-11-what-are-the-steps-toward-compliance"
+                class="text-[#5d770d] hover:underline"
+                >{__("the steps toward compliance")}</a
+              >.
+            </p>
           </div>
         </section>
 
@@ -491,7 +503,20 @@ const breadcrumbSchema = {
                   __(
                     "This makes Probo suitable for organizations that are growing in complexity but still value speed and clarity.",
                   )
-                }
+                }{" "}
+                {__("Read more about")}
+                <a
+                  href="/blog/2025-02-04-the-case-for-open-source-compliance"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("the case for open-source compliance")}</a
+                >
+                {__("and see how")}
+                <a
+                  href="/stories/vybe-soc2"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("Vybe got SOC 2 certified")}</a
+                >
+                {__("using Probo.")}
               </p>
             </div>
           </div>
@@ -586,7 +611,13 @@ const breadcrumbSchema = {
                   __(
                     "Vanta works well when compliance is the primary goal. It becomes less suitable when organizations need to structure risk ownership and governance at scale.",
                   )
-                }
+                }{" "}
+                {__("We explore this further in")}
+                <a
+                  href="/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("why a one-size-fits-all solution is not ideal")}</a
+                >.
               </p>
             </div>
           </div>

--- a/src/pages/hub/what-is-compliance-software.astro
+++ b/src/pages/hub/what-is-compliance-software.astro
@@ -224,9 +224,16 @@ const breadcrumbSchema = {
                       "Adhering to the laws, regulations, and industry standards (such as",
                     )
                   }
-                  <strong>{__("SOC 2, ISO 27001, GDPR, and HIPAA")}</strong>{
-                    __(") that govern your industry.")
-                  }
+                  <strong
+                    ><a
+                      href="/blog/2025-10-28-what-is-soc2"
+                      class="text-[#5d770d] hover:underline">{__("SOC 2")}</a
+                    >, <a
+                      href="/blog/2025-10-12-how-long-for-iso27001"
+                      class="text-[#5d770d] hover:underline"
+                      >{__("ISO 27001")}</a
+                    >, {__("GDPR, and HIPAA")}</strong
+                  >{__(") that govern your industry.")}
                 </p>
               </div>
             </div>
@@ -335,6 +342,16 @@ const breadcrumbSchema = {
                     "allowing you to map a single control to dozens of different regulations. You do the work once, and the platform proves your compliance across every framework you need to satisfy.",
                   )
                 }
+                {" "}{
+                  __(
+                    "If you're weighing which framework to pursue first, see our guide on",
+                  )
+                }
+                <a
+                  href="/blog/2025-10-08-soc2-or-iso27001"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("SOC 2 vs ISO 27001")}</a
+                >.
               </p>
             </div>
 
@@ -364,6 +381,15 @@ const breadcrumbSchema = {
                   )
                 }
               </p>
+              <p class="mt-4">
+                {__("See how")}
+                <a
+                  href="/stories/blaxel-soc2"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("Blaxel achieved SOC 2")}</a
+                >
+                {__("with Probo's managed compliance approach.")}
+              </p>
             </div>
 
             <!-- E. The Human-in-the-Loop -->
@@ -384,6 +410,13 @@ const breadcrumbSchema = {
                     "That's where Probo's managed compliance service comes in. For teams that want to stay focused on building their product and running the business, Probo can step in with experienced compliance experts who help run the program, deal with auditors, and keep things on track.",
                   )
                 }
+                {" "}{__("Learn more about")}
+                <a
+                  href="/blog/2025-10-17-what-is-hands-off-compliance"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("hands-off compliance")}</a
+                >
+                {__("and how it works in practice.")}
               </p>
             </div>
           </div>
@@ -464,7 +497,13 @@ const breadcrumbSchema = {
                   __(
                     "It combines a solid automation platform with real human expertise when you need it, so compliance is practical, effective, and manageable, not just another tool to maintain.",
                   )
-                }</span
+                }
+                {" "}{__("Read more about")}
+                <a
+                  href="/blog/2025-02-17-why-a-one-size-fit-all-solution-like-vanta-is-not-ideal"
+                  class="text-[#5d770d] hover:underline"
+                  >{__("why one-size-fits-all solutions fall short")}</a
+                >.</span
               >
             </p>
           </div>


### PR DESCRIPTION
## Summary
- Add ~55 internal links across 22 files to improve cross-linking between blog posts, customer stories, and hub pages
- Blog posts (12 files): cross-link related SOC 2, ISO 27001, security, and compliance articles that previously had zero internal links
- Customer stories (4 files): add links to relevant blog posts (framework guides, timelines, compliance steps) — all 4 stories had zero internal links before
- Hub pages (6 files): add outbound links to blog posts and customer stories — hub pages are not linked to from other content

## Test plan
- [x] `npm run build` passes
- [ ] Spot-check links on a few blog posts, stories, and hub pages in the dev server