### PR TITLE
Shorten Stripe blog post title

### DIFF
--- a/src/content/blog/2026-03-31-stripe-security-101.mdx
+++ b/src/content/blog/2026-03-31-stripe-security-101.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stripe Security Checklist for SaaS: 2FA, SAML/SCIM & Automatic Payouts"
+title: "Stripe Security Checklist: 2FA, SAML/SCIM & Automatic Payouts"
 date: 2026-03-31
 excerpt: "Stripe is probably the most used payment platform in SaaS. Three settings, thirty minutes of work, and your payment platform stops being a security gap."
 author:


### PR DESCRIPTION
Remove "for SaaS" from the Stripe security checklist blog post title to make it shorter and more broadly applicable.