### PR TITLE
Add Microsoft Entra ID SSO doc and fix SAML/SCIM endpoints

### DIFF
--- a/src/content/docs/docs/product/scim/google-workspace.mdx
+++ b/src/content/docs/docs/product/scim/google-workspace.mdx
@@ -22,21 +22,21 @@ The Google Workspace Bridge connects to Google's Admin Directory API using OAuth
 
 ### Mapped Attributes
 
-| Google Workspace Field | SCIM Attribute |
-|----------------------|----------------|
-| Primary email | `userName`, `emails` |
-| Display name | `displayName` |
-| First name | `name.givenName` |
-| Last name | `name.familyName` |
-| Suspended status | `active` |
-| Job title | `title` |
-| Department | `enterprise:department` |
-| Cost center | `enterprise:costCenter` |
-| Employee ID | `enterprise:employeeNumber` |
-| Manager email | `enterprise:manager` |
-| Language | `preferredLanguage` |
+| Google Workspace Field | SCIM Attribute              |
+| ---------------------- | --------------------------- |
+| Primary email          | `userName`, `emails`        |
+| Display name           | `displayName`               |
+| First name             | `name.givenName`            |
+| Last name              | `name.familyName`           |
+| Suspended status       | `active`                    |
+| Job title              | `title`                     |
+| Department             | `enterprise:department`     |
+| Cost center            | `enterprise:costCenter`     |
+| Employee ID            | `enterprise:employeeNumber` |
+| Manager email          | `enterprise:manager`        |
+| Language               | `preferredLanguage`         |
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 ## Step 1: Create Google OAuth Credentials
 
@@ -50,19 +50,19 @@ import { Steps } from '@astrojs/starlight/components';
 6. Click **+ Create Credentials** > **OAuth client ID**
 7. Configure the OAuth consent screen if prompted:
 
-   | Field | Value |
-   |-------|-------|
-   | **App name** | `Probo SCIM Bridge` |
-   | **User support email** | Your admin email |
-   | **Scopes** | `https://www.googleapis.com/auth/admin.directory.user.readonly` |
+   | Field                  | Value                                                           |
+   | ---------------------- | --------------------------------------------------------------- |
+   | **App name**           | `Probo SCIM Bridge`                                             |
+   | **User support email** | Your admin email                                                |
+   | **Scopes**             | `https://www.googleapis.com/auth/admin.directory.user.readonly` |
 
 8. Create the OAuth client ID:
 
-   | Field | Value |
-   |-------|-------|
-   | **Application type** | `Web application` |
-   | **Name** | `Probo SCIM Bridge` |
-   | **Authorized redirect URIs** | `https://your-probo-domain.com/connect/google/callback` |
+   | Field                        | Value                                                              |
+   | ---------------------------- | ------------------------------------------------------------------ |
+   | **Application type**         | `Web application`                                                  |
+   | **Name**                     | `Probo SCIM Bridge`                                                |
+   | **Authorized redirect URIs** | `https://your-probo-domain.com/api/console/v1/connectors/complete` |
 
 9. Save the **Client ID** and **Client Secret**
 
@@ -77,9 +77,9 @@ import { Steps } from '@astrojs/starlight/components';
 3. Click **Add Connector** and select **Google Workspace**
 4. Enter your OAuth credentials:
 
-   | Field | Value |
-   |-------|-------|
-   | **Client ID** | Your Google OAuth Client ID |
+   | Field             | Value                           |
+   | ----------------- | ------------------------------- |
+   | **Client ID**     | Your Google OAuth Client ID     |
    | **Client Secret** | Your Google OAuth Client Secret |
 
 5. Click **Authorize** to complete the OAuth flow — you'll be redirected to Google to grant access
@@ -150,7 +150,7 @@ For the best experience, combine SCIM Bridge provisioning with SAML SSO:
 
 This means users get automatic Probo accounts when they join your organization and lose access when they leave, with no manual account management needed.
 
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard

--- a/src/content/docs/docs/product/sso/google-workspace.mdx
+++ b/src/content/docs/docs/product/sso/google-workspace.mdx
@@ -13,18 +13,18 @@ This guide walks you through setting up SAML Single Sign-On between Google Works
 - Access to your DNS settings for domain verification
 
 ## Prepare Probo Information
-   
+
 Before configuring Google Workspace, gather these Probo service provider details:
 
-| Field | Value |
-|-------|-------|
-| **ACS URL** | `https://your-probo-domain.com/auth/saml/acs` |
-| **Entity ID** | `https://your-probo-domain.com/auth/saml/metadata` |
-| **Start URL** | `https://your-probo-domain.com` (optional) |
+| Field         | Value                                                            |
+| ------------- | ---------------------------------------------------------------- |
+| **ACS URL**   | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+| **Entity ID** | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
+| **Start URL** | `https://your-probo-domain.com` (optional)                       |
 
 Replace `your-probo-domain.com` with your actual Probo domain.
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 ## Domain Verification
 
@@ -58,41 +58,42 @@ Before configuring anything else, you must verify domain ownership:
 3. Click **Add app** → **Add custom SAML app**
 4. Configure the app details:
 
-   | Field | Value |
-   |-------|-------|
-   | **App name** | `Probo` |
-   | **Description** | `Probo Compliance Management Platform` |
+   | Field           | Value                                                                                                       |
+   | --------------- | ----------------------------------------------------------------------------------------------------------- |
+   | **App name**    | `Probo`                                                                                                     |
+   | **Description** | `Probo Compliance Management Platform`                                                                      |
    | **Upload logo** | Download from [GitHub](https://github.com/getprobo/probo/blob/main/apps/console/public/logo.png) (optional) |
 
 5. Click **Continue**
 6. **Save the Google Identity Provider details** that appear (you'll need these for Probo configuration):
 
-   | Field | Example Value | Notes |
-   |-------|---------------|-------|
-   | **SSO URL** | `https://accounts.google.com/o/saml2/idp?idpid=XXXXXXXXX` | Copy this exact URL |
-   | **Entity ID** | `https://accounts.google.com/o/saml2?idpid=XXXXXXXXX` | Copy this exact URL |
-   | **Certificate** | X.509 Certificate text | Download the certificate or copy the X.509 certificate text |
+   | Field           | Example Value                                             | Notes                                                       |
+   | --------------- | --------------------------------------------------------- | ----------------------------------------------------------- |
+   | **SSO URL**     | `https://accounts.google.com/o/saml2/idp?idpid=XXXXXXXXX` | Copy this exact URL                                         |
+   | **Entity ID**   | `https://accounts.google.com/o/saml2?idpid=XXXXXXXXX`     | Copy this exact URL                                         |
+   | **Certificate** | X.509 Certificate text                                    | Download the certificate or copy the X.509 certificate text |
+
 7. Click **Continue**
 8. Configure the service provider details:
 
-   | Field | Value |
-   |-------|-------|
-   | **ACS URL** | `https://your-probo-domain.com/connect/saml/consume` |
-   | **Entity ID** | `https://your-probo-domain.com/connect/saml/metadata` |
-   | **Start URL** | `[SAML Configuration ID]` (optional - see note below) |
-   | **Name ID format** | `EMAIL` |
-   | **Name ID** | `Basic Information > Primary email` |
-   
+   | Field              | Value                                                            |
+   | ------------------ | ---------------------------------------------------------------- |
+   | **ACS URL**        | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+   | **Entity ID**      | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
+   | **Start URL**      | `[SAML Configuration ID]` (optional - see note below)            |
+   | **Name ID format** | `EMAIL`                                                          |
+   | **Name ID**        | `Basic Information > Primary email`                              |
+
    **Important**: The **Start URL** is optional but if you want to support IdP-initiated login flows, it MUST be set to your exact SAML configuration ID (not a placeholder). If set incorrectly, SSO will not work. You'll get this ID after creating the SAML configuration in Probo.
 
 9. Click **Continue**
 10. Configure the attribute mappings:
 
-    | Google Directory attributes | App attributes |
-    |----------------------------|----------------|
-    | **Basic Information > Primary email** | `email` |
-    | **Basic Information > First name** | `firstName` |
-    | **Basic Information > Last name** | `lastName` |
+    | Google Directory attributes           | App attributes |
+    | ------------------------------------- | -------------- |
+    | **Basic Information > Primary email** | `email`        |
+    | **Basic Information > First name**    | `firstName`    |
+    | **Basic Information > Last name**     | `lastName`     |
 
 11. Click **Finish**
 12. In the app list, click on your **Probo** app
@@ -111,32 +112,32 @@ Before configuring anything else, you must verify domain ownership:
 3. Click **Add SAML Configuration**
 4. Configure the basic settings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **Email Domain** | `your-company.com` | Your organization's email domain |
-   | **Enforcement Policy** | `OPTIONAL` | Recommended for initial setup |
+   | Field                  | Value              | Notes                            |
+   | ---------------------- | ------------------ | -------------------------------- |
+   | **Email Domain**       | `your-company.com` | Your organization's email domain |
+   | **Enforcement Policy** | `OPTIONAL`         | Recommended for initial setup    |
 
 5. Configure the Identity Provider settings with values from Google Workspace:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **IdP Entity ID** | `https://accounts.google.com/o/saml2?idpid=XXXXXXXXX` | Copy from Google Workspace setup |
-   | **IdP SSO URL** | `https://accounts.google.com/o/saml2/idp?idpid=XXXXXXXXX` | Copy from Google Workspace setup |
-   | **IdP Certificate** | `[X.509 Certificate text]` | Paste the certificate from Google |
+   | Field               | Value                                                     | Notes                             |
+   | ------------------- | --------------------------------------------------------- | --------------------------------- |
+   | **IdP Entity ID**   | `https://accounts.google.com/o/saml2?idpid=XXXXXXXXX`     | Copy from Google Workspace setup  |
+   | **IdP SSO URL**     | `https://accounts.google.com/o/saml2/idp?idpid=XXXXXXXXX` | Copy from Google Workspace setup  |
+   | **IdP Certificate** | `[X.509 Certificate text]`                                | Paste the certificate from Google |
 
 6. Configure the attribute mappings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **Email Attribute** | `email` | Maps to user email |
-   | **First Name Attribute** | `firstName` | Maps to user first name |
-   | **Last Name Attribute** | `lastName` | Maps to user last name |
-   | **Role Attribute** | `[Leave empty]` | Unless you've configured custom attributes |
+   | Field                    | Value           | Notes                                      |
+   | ------------------------ | --------------- | ------------------------------------------ |
+   | **Email Attribute**      | `email`         | Maps to user email                         |
+   | **First Name Attribute** | `firstName`     | Maps to user first name                    |
+   | **Last Name Attribute**  | `lastName`      | Maps to user last name                     |
+   | **Role Attribute**       | `[Leave empty]` | Unless you've configured custom attributes |
 
 7. Configure user settings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
+   | Field           | Value     | Notes                                             |
+   | --------------- | --------- | ------------------------------------------------- |
    | **Auto Signup** | `Enabled` | Allows new users to sign up automatically via SSO |
 
 8. Click **Save Configuration** (the configuration will be created but not yet enabled)
@@ -163,31 +164,37 @@ This enables IdP-initiated login flows, allowing users to click on Probo from th
 ## Troubleshooting
 
 ### "App isn't verified" Error
+
 - **Cause**: Google Workspace app not enabled for users
 - **Solution**: Enable the app for all users or specific organizational units in Google Admin Console
 
 ### "Access blocked" Error
+
 - **Cause**: User not in allowed organizational units
 - **Solution**: Check Google Workspace user access settings and ensure users are in the correct organizational units
 
 ### "Invalid SAML Response" Error
+
 - **Cause**: Incorrect ACS URL or Entity ID configuration
 - **Solution**: Verify URLs match exactly between Google Workspace and Probo:
-  - ACS URL: `https://your-probo-domain.com/connect/saml/consume`
-  - Entity ID: `https://your-probo-domain.com/connect/saml/metadata`
+  - ACS URL: `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`
+  - Entity ID: `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata`
 
 ### Attributes Not Mapping
+
 - **Cause**: Incorrect attribute names in Probo configuration
 - **Solution**: Use exact attribute names: `email`, `firstName`, `lastName`
 
 ### Debugging Steps
 
 #### Check Google Workspace Logs
+
 1. Go to Google Admin Console → **Reporting** → **Audit and investigation** → **SAML apps**
 2. Look for failed authentication attempts
 3. Check error messages and timestamps for debugging clues
 
 #### Verify Certificate Format
+
 Ensure the certificate is properly formatted without line breaks:
 
 ```
@@ -197,6 +204,7 @@ Ensure the certificate is properly formatted without line breaks:
 ```
 
 #### Test Metadata URL
+
 If using metadata URL, test it in a browser to ensure it returns valid XML:
 
 ```

--- a/src/content/docs/docs/product/sso/microsoft-entra-id.mdx
+++ b/src/content/docs/docs/product/sso/microsoft-entra-id.mdx
@@ -1,0 +1,228 @@
+---
+title: Microsoft Entra ID SSO
+description: Configure SAML Single Sign-On with Microsoft Entra ID (Azure AD) for Probo
+---
+
+This guide walks you through setting up SAML Single Sign-On between Microsoft Entra ID (formerly Azure Active Directory) and Probo.
+
+## Prerequisites
+
+- Microsoft Entra ID administrator access (or Application Administrator role)
+- Probo organization administrator access
+- Your Probo domain (e.g., `probo.example.com`)
+- Access to your DNS settings for domain verification
+
+## Prepare Probo Information
+
+Before configuring Microsoft Entra ID, gather these Probo service provider details:
+
+| Field         | Value                                                            |
+| ------------- | ---------------------------------------------------------------- |
+| **ACS URL**   | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+| **Entity ID** | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
+
+Replace `your-probo-domain.com` with your actual Probo domain.
+
+## Domain Verification
+
+Before configuring anything else, you must verify domain ownership:
+
+import { Steps } from "@astrojs/starlight/components";
+
+<Steps>
+
+1. Log in to Probo as an organization administrator
+2. Go to **Organization Settings** → **Authentication** → **SAML**
+3. Click **Verify Domain** (if no configurations exist yet, this option will be available)
+4. Copy the provided TXT record value
+5. Add a TXT record to your domain's DNS settings:
+   ```
+   Type: TXT
+   Name: _probo-domain-verification.your-company.com
+   Value: [Verification token from Probo]
+   TTL: 300 (or your DNS provider's default)
+   ```
+6. Wait for DNS propagation (usually 5-15 minutes)
+7. In Probo, click **Complete Verification**
+8. If successful, the domain status will show as "Verified"
+
+</Steps>
+
+## Configure Microsoft Entra ID
+
+<Steps>
+
+1. Sign in to the [Microsoft Entra admin center](https://entra.microsoft.com/)
+2. Go to **Identity** → **Applications** → **Enterprise applications**
+3. Click **New application** → **Create your own application**
+4. Enter `Probo` as the application name
+5. Select **Integrate any other application you don't find in the gallery (Non-gallery)**
+6. Click **Create**
+7. In the application overview, go to **Single sign-on** → select **SAML**
+8. In **Basic SAML Configuration**, click **Edit** and configure:
+
+   | Field                                          | Value                                                            |
+   | ---------------------------------------------- | ---------------------------------------------------------------- |
+   | **Identifier (Entity ID)**                     | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
+   | **Reply URL (Assertion Consumer Service URL)** | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+   | **Relay State**                                | `[SAML Configuration ID]` (optional - see note below)            |
+   | **Sign on URL**                                | `https://your-probo-domain.com` (optional)                       |
+
+   **Important**: The **Relay State** is optional but if you want to support IdP-initiated login flows, it MUST be set to your exact SAML configuration ID (not a placeholder). If set incorrectly, SSO will not work. You'll get this ID after creating the SAML configuration in Probo. You can initially leave this empty and update it later with the exact configuration ID.
+
+9. Click **Save**
+10. In **Attributes & Claims**, click **Edit** and configure the following claims:
+
+    | Claim name  | Source attribute |
+    | ----------- | ---------------- |
+    | `email`     | `user.mail`      |
+    | `firstName` | `user.givenname` |
+    | `lastName`  | `user.surname`   |
+
+    To add each claim:
+    - Click **Add new claim**
+    - Enter the claim name (e.g., `email`)
+    - Set **Source** to `Attribute`
+    - Select the corresponding **Source attribute**
+    - Click **Save**
+
+    Also verify that the **Unique User Identifier (Name ID)** is set to `user.userprincipalname` or `user.mail` with the format `Email address`.
+
+11. In **SAML Certificates**, download the **Certificate (Base64)** and copy:
+    - **Login URL** (this is the IdP SSO URL)
+    - **Microsoft Entra Identifier** (this is the IdP Entity ID)
+
+12. Go to **Users and groups**
+13. Click **Add user/group**
+14. Select users or groups that should have access to Probo
+15. Click **Assign**
+
+</Steps>
+
+## Configure Probo
+
+<Steps>
+
+1. Log in to Probo as an organization administrator
+2. Go to **Organization Settings** → **Authentication** → **SAML**
+3. Click **Add SAML Configuration**
+4. Configure the basic settings:
+
+   | Field                  | Value              | Notes                            |
+   | ---------------------- | ------------------ | -------------------------------- |
+   | **Email Domain**       | `your-company.com` | Your organization's email domain |
+   | **Enforcement Policy** | `OPTIONAL`         | Recommended for initial setup    |
+
+5. Configure the Identity Provider settings with values from Microsoft Entra ID:
+
+   | Field               | Value                          | Notes                                    |
+   | ------------------- | ------------------------------ | ---------------------------------------- |
+   | **IdP Entity ID**   | `[Microsoft Entra Identifier]` | Copy from Entra ID setup                 |
+   | **IdP SSO URL**     | `[Login URL]`                  | Copy from Entra ID setup                 |
+   | **IdP Certificate** | `[Certificate (Base64)]`       | Paste the downloaded certificate content |
+
+6. Configure the attribute mappings:
+
+   | Field                    | Value           | Notes                                  |
+   | ------------------------ | --------------- | -------------------------------------- |
+   | **Email Attribute**      | `email`         | Maps to user email                     |
+   | **First Name Attribute** | `firstName`     | Maps to user first name                |
+   | **Last Name Attribute**  | `lastName`      | Maps to user last name                 |
+   | **Role Attribute**       | `[Leave empty]` | Unless you've configured custom claims |
+
+7. Configure user settings:
+
+   | Field           | Value     | Notes                                             |
+   | --------------- | --------- | ------------------------------------------------- |
+   | **Auto Signup** | `Enabled` | Allows new users to sign up automatically via SSO |
+
+8. Click **Save Configuration**
+9. **Copy the SAML Configuration ID** that appears after saving (e.g., `saml_config_1a2b3c4d`)
+
+</Steps>
+
+## Update Entra ID Relay State
+
+Return to Microsoft Entra ID to enable IdP-initiated login:
+
+<Steps>
+
+1. Go to your Probo enterprise application in the Entra admin center
+2. Click **Single sign-on** → **Edit** Basic SAML Configuration
+3. In the **Relay State** field, enter your SAML configuration ID
+4. Click **Save**
+
+</Steps>
+
+## Troubleshooting
+
+### "AADSTS75005: The request is not a valid Saml2 protocol message" Error
+
+- **Cause**: Incorrect Reply URL or Entity ID configuration
+- **Solution**: Verify that the Reply URL and Entity ID in Entra ID exactly match your Probo configuration:
+  - Reply URL: `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`
+  - Entity ID: `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata`
+
+### "AADSTS50105: User not assigned to application" Error
+
+- **Cause**: User has not been assigned to the Probo enterprise application
+- **Solution**: Go to the enterprise application → **Users and groups** → assign the user or a group containing the user
+
+### "AADSTS700016: Application not found" Error
+
+- **Cause**: Incorrect Entity ID in Probo or application not properly configured
+- **Solution**: Verify the Microsoft Entra Identifier matches the IdP Entity ID configured in Probo
+
+### Attributes Not Mapping
+
+- **Cause**: Claims not configured correctly in Entra ID
+- **Solution**: Verify that custom claims are configured with exact names: `email`, `firstName`, `lastName`. Check under **Single sign-on** → **Attributes & Claims**
+
+### "Invalid RelayState" Error
+
+- **Cause**: Incorrect Relay State configuration
+- **Solution**: Ensure Relay State is either empty or set to the exact SAML configuration ID from Probo
+
+### Debugging Steps
+
+#### Check Entra ID Sign-in Logs
+
+1. Go to the Entra admin center → **Identity** → **Monitoring & health** → **Sign-in logs**
+2. Filter by the Probo application
+3. Click on a failed sign-in attempt to view error details and troubleshooting recommendations
+
+#### Test SAML Response
+
+1. In the Probo enterprise application, go to **Single sign-on**
+2. Click **Test this application**
+3. Review the SAML response for errors
+
+## Advanced Configuration
+
+### Custom Claims
+
+To map additional Entra ID user attributes:
+
+1. In the enterprise application, go to **Single sign-on** → **Attributes & Claims**
+2. Click **Add new claim**
+3. Map additional directory attributes as needed
+4. Update the corresponding attribute mappings in Probo
+
+### Conditional Access
+
+Control access using Microsoft Entra ID Conditional Access policies:
+
+1. Go to **Identity** → **Protection** → **Conditional Access**
+2. Create a new policy targeting the Probo application
+3. Configure conditions (location, device, risk level, etc.)
+4. Set appropriate access controls (grant, block, require MFA)
+
+### Group-Based Access
+
+Restrict access using Entra ID groups:
+
+1. In the enterprise application, go to **Users and groups**
+2. Assign groups instead of individual users
+3. Manage access by adding/removing users from the assigned groups
+
+For detailed troubleshooting and advanced configuration options, see the [SSO Overview](/docs/product/sso/overview) guide.

--- a/src/content/docs/docs/product/sso/okta.mdx
+++ b/src/content/docs/docs/product/sso/okta.mdx
@@ -16,10 +16,10 @@ This guide walks you through setting up SAML Single Sign-On between Okta and Pro
 
 Before configuring Okta, gather these Probo service provider details:
 
-| Field | Value |
-|-------|-------|
-| **ACS URL** | `https://your-probo-domain.com/auth/saml/acs` |
-| **Entity ID** | `https://your-probo-domain.com/auth/saml/metadata` |
+| Field         | Value                                                            |
+| ------------- | ---------------------------------------------------------------- |
+| **ACS URL**   | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+| **Entity ID** | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
 
 Replace `your-probo-domain.com` with your actual Probo domain.
 
@@ -27,7 +27,7 @@ Replace `your-probo-domain.com` with your actual Probo domain.
 
 Before configuring anything else, you must verify domain ownership:
 
-import { Steps } from '@astrojs/starlight/components';
+import { Steps } from "@astrojs/starlight/components";
 
 <Steps>
 
@@ -59,34 +59,34 @@ import { Steps } from '@astrojs/starlight/components';
 5. Click **Next**
 6. Configure the general settings:
 
-   | Field | Value |
-   |-------|-------|
-   | **App name** | `Probo` |
-   | **App logo** | Upload Probo logo (optional) |
-   | **App visibility** | Check desired options |
+   | Field              | Value                        |
+   | ------------------ | ---------------------------- |
+   | **App name**       | `Probo`                      |
+   | **App logo**       | Upload Probo logo (optional) |
+   | **App visibility** | Check desired options        |
 
 7. Click **Next**
 8. Configure the SAML settings:
 
-   | Field | Value |
-   |-------|-------|
-   | **Single sign on URL** | `https://your-probo-domain.com/connect/saml/consume` |
-   | **Use this for Recipient URL and Destination URL** | ☑️ (Check this box) |
-   | **Audience URI (SP Entity ID)** | `https://your-probo-domain.com/connect/saml/metadata` |
-   | **Default Relay State** | `[SAML Configuration ID]` (optional - see note below) |
-   | **Name ID format** | `EmailAddress` |
-   | **Application username** | `Email` |
+   | Field                                              | Value                                                            |
+   | -------------------------------------------------- | ---------------------------------------------------------------- |
+   | **Single sign on URL**                             | `https://your-probo-domain.com/api/connect/v1/saml/2.0/consume`  |
+   | **Use this for Recipient URL and Destination URL** | ☑️ (Check this box)                                              |
+   | **Audience URI (SP Entity ID)**                    | `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata` |
+   | **Default Relay State**                            | `[SAML Configuration ID]` (optional - see note below)            |
+   | **Name ID format**                                 | `EmailAddress`                                                   |
+   | **Application username**                           | `Email`                                                          |
 
    **Important**: The **Default Relay State** is optional but if you want to support IdP-initiated login flows, it MUST be set to your exact SAML configuration ID (not a placeholder). If set incorrectly, SSO will not work. You'll get this ID after creating the SAML configuration in Probo. You can initially leave this empty and update it later with the exact configuration ID.
 
 9. Add the following attribute statements:
 
-   | Name | Name format | Value |
-   |------|-------------|-------|
-   | `email` | Unspecified | `user.email` |
-   | `firstName` | Unspecified | `user.firstName` |
-   | `lastName` | Unspecified | `user.lastName` |
-   | `role` | Unspecified | `user.role` (optional) |
+   | Name        | Name format | Value                  |
+   | ----------- | ----------- | ---------------------- |
+   | `email`     | Unspecified | `user.email`           |
+   | `firstName` | Unspecified | `user.firstName`       |
+   | `lastName`  | Unspecified | `user.lastName`        |
+   | `role`      | Unspecified | `user.role` (optional) |
 
 10. Click **Next**
 11. Select **I'm an Okta customer adding an internal app**
@@ -114,32 +114,32 @@ import { Steps } from '@astrojs/starlight/components';
 3. Click **Add SAML Configuration**
 4. Configure the basic settings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **Email Domain** | `your-company.com` | Your organization's email domain |
-   | **Enforcement Policy** | `OPTIONAL` | Recommended for initial setup |
+   | Field                  | Value              | Notes                            |
+   | ---------------------- | ------------------ | -------------------------------- |
+   | **Email Domain**       | `your-company.com` | Your organization's email domain |
+   | **Enforcement Policy** | `OPTIONAL`         | Recommended for initial setup    |
 
 5. Configure the Identity Provider settings with values from Okta:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **IdP Entity ID** | `[Identity Provider Issuer]` | Copy from Okta setup |
-   | **IdP SSO URL** | `[Identity Provider Single Sign-On URL]` | Copy from Okta setup |
-   | **IdP Certificate** | `[X.509 Certificate]` | Copy from Okta setup |
+   | Field               | Value                                    | Notes                |
+   | ------------------- | ---------------------------------------- | -------------------- |
+   | **IdP Entity ID**   | `[Identity Provider Issuer]`             | Copy from Okta setup |
+   | **IdP SSO URL**     | `[Identity Provider Single Sign-On URL]` | Copy from Okta setup |
+   | **IdP Certificate** | `[X.509 Certificate]`                    | Copy from Okta setup |
 
 6. Configure the attribute mappings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
-   | **Email Attribute** | `email` | Maps to user email |
+   | Field                    | Value       | Notes                   |
+   | ------------------------ | ----------- | ----------------------- |
+   | **Email Attribute**      | `email`     | Maps to user email      |
    | **First Name Attribute** | `firstName` | Maps to user first name |
-   | **Last Name Attribute** | `lastName` | Maps to user last name |
-   | **Role Attribute** | `role` | If configured in Okta |
+   | **Last Name Attribute**  | `lastName`  | Maps to user last name  |
+   | **Role Attribute**       | `role`      | If configured in Okta   |
 
 7. Configure user settings:
 
-   | Field | Value | Notes |
-   |-------|-------|-------|
+   | Field           | Value     | Notes                                             |
+   | --------------- | --------- | ------------------------------------------------- |
    | **Auto Signup** | `Enabled` | Allows new users to sign up automatically via SSO |
 
 8. Click **Save Configuration**
@@ -163,25 +163,30 @@ Return to Okta to enable IdP-initiated login:
 ## Troubleshooting
 
 ### "SAML assertion audience mismatch" Error
+
 - **Cause**: Audience URI mismatch between Okta and Probo
 - **Solution**: Ensure Audience URI in Okta exactly matches your Entity ID:
-  - Should be: `https://your-probo-domain.com/connect/saml/metadata`
+  - Should be: `https://your-probo-domain.com/api/connect/v1/saml/2.0/metadata`
 
 ### "User not assigned to application" Error
+
 - **Cause**: User not assigned to Probo app in Okta
 - **Solution**: Assign user to the application in Okta's Assignments tab
 
 ### Attributes Not Mapping
+
 - **Cause**: Incorrect attribute statement names in Okta
 - **Solution**: Verify attribute statement names match exactly: `email`, `firstName`, `lastName`
 
 ### "Invalid RelayState" Error
+
 - **Cause**: Incorrect Default Relay State configuration
 - **Solution**: Ensure Default Relay State is either empty or set to the exact SAML configuration ID from Probo
 
 ### Debugging Steps
 
 #### Check Okta System Log
+
 1. Go to Okta Admin Console → **Reports** → **System Log**
 2. Filter by application name (Probo)
 3. Look for authentication failures and error details

--- a/src/content/docs/docs/product/sso/overview.mdx
+++ b/src/content/docs/docs/product/sso/overview.mdx
@@ -9,7 +9,7 @@ Probo supports SAML 2.0 Single Sign-On (SSO) integration with popular identity p
 
 Probo works with any SAML 2.0 compliant identity provider. We provide detailed setup guides for the most popular providers:
 
-import { LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';
+import { LinkCard, CardGrid, Steps } from "@astrojs/starlight/components";
 
 <CardGrid>
   <LinkCard
@@ -22,10 +22,15 @@ import { LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';
     description="Set up SAML authentication with Okta"
     href="/docs/product/sso/okta"
   />
+  <LinkCard
+    title="Microsoft Entra ID"
+    description="Configure SSO with Microsoft Entra ID (Azure AD)"
+    href="/docs/product/sso/microsoft-entra-id"
+  />
 </CardGrid>
 
 **Other supported providers:**
-- Azure Active Directory
+
 - OneLogin
 - Auth0
 - ADFS (Active Directory Federation Services)
@@ -39,11 +44,11 @@ import { LinkCard, CardGrid, Steps } from '@astrojs/starlight/components';
 
 Before configuring your identity provider, you'll need these Probo service provider details:
 
-| Field | Value |
-|-------|-------|
-| **Entity ID** | `https://your-domain.com/auth/saml/metadata` |
-| **ACS URL** | `https://your-domain.com/auth/saml/acs` |
-| **Metadata URL** | `https://your-domain.com/auth/saml/metadata` |
+| Field            | Value                                                      |
+| ---------------- | ---------------------------------------------------------- |
+| **Entity ID**    | `https://your-domain.com/api/connect/v1/saml/2.0/metadata` |
+| **ACS URL**      | `https://your-domain.com/api/connect/v1/saml/2.0/consume`  |
+| **Metadata URL** | `https://your-domain.com/api/connect/v1/saml/2.0/metadata` |
 
 Replace `your-domain.com` with your actual Probo domain.
 
@@ -67,31 +72,30 @@ SAML_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
 
 The SSO setup process involves:
 
-
 <Steps>
 
 1. **Configure your Identity Provider**
-   
+
    Set up Probo as a SAML application in your IdP (Okta, Google Workspace, etc.)
 
 2. **Configure Probo**
-   
+
    Add your IdP settings in Probo's SAML configuration
 
 3. **Update RelayState**
-   
+
    Set IdP RelayState to SAML config ID for IdP-initiated login support
 
 4. **Domain Verification**
-   
+
    Verify ownership of your email domain using DNS TXT records
 
 5. **Testing**
-   
+
    Test both SP-initiated and IdP-initiated login flows
 
 6. **Enforcement**
-   
+
    Choose enforcement policy (optional/required) and enable SSO
 
 </Steps>
@@ -107,32 +111,35 @@ For IdP-initiated flows to work properly, the **RelayState** must be set to your
 
 Probo supports three SAML enforcement policies:
 
-| Policy | SSO Available | Password Login | Description | Use Case |
-|--------|---------------|----------------|-------------|----------|
-| **OFF** | ❌ | ✅ | SSO is disabled, only password login | SSO not configured |
-| **OPTIONAL** | ✅ | ✅ | Users can choose SSO or password | Gradual SSO rollout |
-| **REQUIRED** | ✅ | ❌ | SSO mandatory for domain users | Full SSO enforcement |
+| Policy       | SSO Available | Password Login | Description                          | Use Case             |
+| ------------ | ------------- | -------------- | ------------------------------------ | -------------------- |
+| **OFF**      | ❌            | ✅             | SSO is disabled, only password login | SSO not configured   |
+| **OPTIONAL** | ✅            | ✅             | Users can choose SSO or password     | Gradual SSO rollout  |
+| **REQUIRED** | ✅            | ❌             | SSO mandatory for domain users       | Full SSO enforcement |
 
 ## Security Requirements
 
 ### Certificate Management
+
 - Use strong certificates (2048-bit RSA minimum)
 - Rotate certificates regularly
 - Store private keys securely
 
 ### Domain Verification
+
 - Always verify domain ownership before enabling SSO
 - Use DNS TXT records for verification
 - Monitor domain verification status
 
 ### Cookie Security
+
 The `auth.cookie.secure` setting **must be set to `true`** for SAML authentication to work properly:
 
 ```yaml
 probod:
   auth:
     cookie:
-      secure: true  # Required for SAML
+      secure: true # Required for SAML
 ```
 
 This is required because SAML uses `SameSite=None` cookies for cross-site POST requests from identity providers, and modern browsers require the `Secure` flag when using `SameSite=None`.
@@ -140,22 +147,27 @@ This is required because SAML uses `SameSite=None` cookies for cross-site POST r
 ## Troubleshooting
 
 ### Invalid SAML Response Error
+
 - **Cause**: Clock skew between Identity Provider and Probo servers
 - **Solution**: Ensure time synchronization (NTP) on both systems. Clock differences greater than 5 minutes can cause SAML failures.
 
 ### Signature Verification Failed Error
+
 - **Cause**: Incorrect certificate or certificate mismatch between IdP and Probo
 - **Solution**: Verify the IdP certificate is correctly copied without line breaks or formatting issues
 
 ### Unknown User Error
+
 - **Cause**: User doesn't exist in Probo and auto-signup is disabled
 - **Solution**: Either enable auto-signup in SAML configuration or create user accounts manually before SSO setup
 
 ### Domain Not Verified Error
+
 - **Cause**: Email domain hasn't been verified in Probo
 - **Solution**: Complete the domain verification process before enabling SSO - this is always the first required step
 
 ### RelayState/Start URL Issues
+
 - **Cause**: Incorrect RelayState configuration for IdP-initiated login
 - **Solution**: Ensure RelayState/Start URL is either empty or set to the exact SAML configuration ID from Probo
 
@@ -174,6 +186,11 @@ Choose your identity provider to get started:
     description="Complete Okta SAML configuration"
     href="/docs/product/sso/okta"
   />
+  <LinkCard
+    title="Microsoft Entra ID Setup"
+    description="Configure SAML with Microsoft Entra ID (Azure AD)"
+    href="/docs/product/sso/microsoft-entra-id"
+  />
 </CardGrid>
 
 ## Migration Guide
@@ -185,19 +202,16 @@ When transitioning from password-based authentication to SSO, follow this phased
 <Steps>
 
 1. **Phase 1: Set enforcement to `OPTIONAL`**
-   
    - Communicate SSO availability to users
    - Provide training and support documentation
    - Monitor adoption rates
 
 2. **Phase 2: User testing and feedback**
-   
    - Help users resolve SSO issues
    - Ensure all users can successfully authenticate
    - Address any attribute mapping issues
 
 3. **Phase 3: Full enforcement**
-   
    - Change enforcement to `REQUIRED`
    - Communicate the change to users
    - Monitor for any access issues
@@ -211,19 +225,19 @@ If issues arise, follow this rollback procedure:
 <Steps>
 
 1. **Change enforcement back to `OPTIONAL` or `OFF`**
-   
+
    Immediately restore user access using password authentication
 
 2. **Communicate alternative login methods to users**
-   
+
    Notify users about the temporary change and available login options
 
 3. **Investigate and resolve issues**
-   
+
    Debug configuration problems, test thoroughly, and prepare fixes
 
 4. **Re-enable when ready**
-   
+
    Return to SSO once all issues are resolved and tested
 
 </Steps>


### PR DESCRIPTION
## Summary
- Add a new SAML SSO guide for Microsoft Entra ID (Azure AD) with full setup instructions, attribute mappings, troubleshooting, and advanced configuration (Conditional Access, group-based access).
- Update all SSO docs (Okta, Google Workspace, overview) to use correct SAML endpoints from the Probo source: `/api/connect/v1/saml/2.0/consume` and `/api/connect/v1/saml/2.0/metadata`.
- Fix the Google Workspace SCIM Bridge OAuth callback URL to `/api/console/v1/connectors/complete`.
- Add Microsoft Entra ID link cards to the SSO overview page.

## Test plan
- [ ] Verify `npm run build` passes
- [ ] Review all endpoint URLs match the Probo source code
- [ ] Check the new Entra ID doc renders correctly in Starlight