### PR TITLE
Add changelog entry for PostHog access review support

### DIFF
--- a/src/content/changelog/2026-05-28-posthog-access-review.mdx
+++ b/src/content/changelog/2026-05-28-posthog-access-review.mdx
@@ -1,0 +1,12 @@
+---
+title: "PostHog in Access Reviews"
+description: "Run access review campaigns using PostHog users and team ownership data directly in Probo."
+date: 2026-05-28
+tags: ["Access Review"]
+---
+
+Access reviews now support PostHog as an identity source.
+
+You can pull PostHog users and ownership context directly into Probo access review campaigns, assign reviewers, and capture decisions in one place.
+
+This removes the spreadsheet step for teams that manage product analytics access in PostHog and keeps review evidence tied to your compliance workflow.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new changelog entry announcing PostHog support in access review campaigns
- include product-facing context on importing PostHog users/ownership into Probo reviews
- tag the update under Access Review

## Validation
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cd8a395-9e55-4199-8444-171aeff66c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cd8a395-9e55-4199-8444-171aeff66c74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

