### PR TITLE
Changelog: Risk Assessment Boundaries

### DIFF
--- a/src/content/changelog/2026-06-09-risk-assessment-boundaries.mdx
+++ b/src/content/changelog/2026-06-09-risk-assessment-boundaries.mdx
@@ -1,0 +1,12 @@
+---
+title: "Risk Assessment Boundaries"
+description: "Group risk assessment nodes into named boundaries so large diagrams stay readable."
+date: 2026-06-09
+tags: ["Console"]
+---
+
+Risk assessment diagrams get messy once a team maps more than a handful of nodes. Everything lives on one flat canvas, so scope boundaries only exist in someone's head.
+
+Boundaries fix that. Create a boundary within a risk assessment scope, then assign nodes to it. The Mermaid diagram renders each boundary as its own labeled subgraph, so you can see at a glance which nodes belong to which part of the system. Boundaries can nest inside each other too, for teams that split assessments by business unit and then by system.
+
+It's available in the console, the CLI (`prb risk-assessment boundary`), and through MCP tools, so however your team builds risk assessments, boundaries come along for free.


### PR DESCRIPTION
Adds a new changelog entry: **Risk Assessment Boundaries**

> Group risk assessment nodes into named boundaries so large diagrams stay readable.

File: `src/content/changelog/2026-06-09-risk-assessment-boundaries.mdx`

_Opened automatically from the Changelog composer._