### PR TITLE
Changelog: More Access Review Connectors

### DIFF
--- a/src/content/changelog/2026-07-13-access-review-scaleway-yousign-railway-crisp.mdx
+++ b/src/content/changelog/2026-07-13-access-review-scaleway-yousign-railway-crisp.mdx
@@ -1,0 +1,14 @@
+---
+title: "More Access Review Connectors"
+description: "Four new managed connectors mean fewer manual access reviews. Provider logos and ownership checks ship before a connection goes live."
+date: 2026-07-13
+images: ["https://www.google.com/s2/favicons?domain=scaleway.com&sz=256", "https://www.google.com/s2/favicons?domain=yousign.com&sz=256", "https://www.google.com/s2/favicons?domain=railway.app&sz=256", "https://www.google.com/s2/favicons?domain=crisp.chat&sz=256"]
+imagesLayout: "logos"
+tags: ["Access Review"]
+---
+
+Access reviews just got easier for four more platforms.
+
+Scaleway, Yousign, Railway, and Crisp now have managed connectors. Each one verifies website and ownership before a connection is allowed. New connectors stay hidden until they are fully configured, so your team never sees a half-set-up integration.
+
+If your stack includes any of these tools, you can now pull access data straight into your review campaigns instead of tracking it by hand.


### PR DESCRIPTION
Adds a new changelog entry: **More Access Review Connectors**

> Four new managed connectors mean fewer manual access reviews. Provider logos and ownership checks ship before a connection goes live.

File: `src/content/changelog/2026-07-13-access-review-scaleway-yousign-railway-crisp.mdx`

_Opened automatically from the Changelog composer._