### PR TITLE
Add Dotfile and Segment access-review connector doc pages

### DIFF
--- a/src/content/docs/docs/product/access-review/directory.mdx
+++ b/src/content/docs/docs/product/access-review/directory.mdx
@@ -73,6 +73,16 @@ import { LinkCard, CardGrid } from "@astrojs/starlight/components";
     description="Probo Marketplace plugin"
     href="/docs/product/access-review/crisp"
   />
+  <LinkCard
+    title="Dotfile"
+    description="Workspace API key"
+    href="/docs/product/access-review/dotfile"
+  />
+  <LinkCard
+    title="Segment"
+    description="Public API token"
+    href="/docs/product/access-review/segment"
+  />
 </CardGrid>
 
 :::note

--- a/src/content/docs/docs/product/access-review/dotfile.mdx
+++ b/src/content/docs/docs/product/access-review/dotfile.mdx
@@ -1,0 +1,61 @@
+---
+title: Dotfile
+description: Connect Dotfile as an access source using a workspace API key
+---
+
+Probo reads your Dotfile workspace's members through the Dotfile API so you can review who has access.
+
+:::caution
+Use a workspace API key created by a workspace **admin**. A Dotfile API key is workspace wide and Dotfile documents no scopes or permissions on it, so any workspace API key can call the users endpoint. Dotfile hashes and encrypts the key, so copy it when you create it. You cannot recover a lost key and will have to generate a new one.
+:::
+
+## Prerequisites
+
+- Probo organization administrator access
+- The **admin** role in the Dotfile workspace (Dotfile requires you to be an admin of the workspace to generate API keys)
+
+## Collected Fields
+
+| Probo field | Dotfile field                                            | Notes                                                       |
+| ----------- | -------------------------------------------------------- | ----------------------------------------------------------- |
+| Name        | `first_name` and `last_name`                             | Falls back to the email address                             |
+| Email       | `email`                                                  |                                                             |
+| Role        | `role`                                                   | `owner`, `admin`, `member`, or the name of a custom role    |
+| Admin       | `role`                                                   | Flagged as an administrator when `role` is `owner` or `admin` |
+| Status      | `suspended_at`                                           | Inactive once a suspension timestamp is set                 |
+| MFA         | <Badge text="Not supported" class="badge-unsupported" /> |                                                             |
+| Last login  | <Badge text="Not supported" class="badge-unsupported" /> |                                                             |
+| External ID | `id`                                                     | Stable identifier used to track the account across reviews  |
+| Created at  | `created_at`                                             | When the user was created in the workspace                  |
+
+Probo requests suspended users as well as active ones, so a suspended member still appears in the campaign, marked inactive.
+
+## Step 1: Create an API Key
+
+import { Steps, Badge } from "@astrojs/starlight/components";
+
+{/* Screenshot pending: save the key-creation dialog to public/docs/access-review/dotfile-create-api-key.webp and restore the image line here. */}
+
+<Steps>
+
+1. In the [Dotfile console](https://app.dotfile.com), signed in as a workspace **admin**, go to **Workspace settings** > **API keys**.
+2. Create a new key and give it a name (e.g. `Probo Access Review`). Dotfile documents no scope or permission to set on a key.
+3. Copy the key and store it securely (password manager, secret manager). Dotfile hashes and encrypts it, so you cannot read it again.
+
+</Steps>
+
+## Step 2: Connect in Probo
+
+<Steps>
+
+1. In Probo, go to **Access Reviews** > **Sources** > **Add Source**.
+2. Find **Dotfile**, click **API Key**, paste the key, and click **Connect**.
+
+</Steps>
+
+Probo pulls your workspace's members into your campaigns.
+
+## Troubleshooting
+
+- **Key rejected.** Confirm a workspace admin generated the key and that it has not been replaced since. Probo sends it in the `X-DOTFILE-API-KEY` header, so a key from a different workspace will not authenticate.
+- **No members appear.** An API key is workspace wide, so check that it belongs to the workspace you intend to review.

--- a/src/content/docs/docs/product/access-review/segment.mdx
+++ b/src/content/docs/docs/product/access-review/segment.mdx
@@ -1,0 +1,65 @@
+---
+title: Segment
+description: Connect Segment as an access source using a Public API token
+---
+
+Probo reads your Segment workspace's members through the Segment Public API so you can review who has access.
+
+:::caution
+Create a **Public API token**, not a Config API token. Segment runs both, and only the Public API token authenticates against the endpoints Probo reads. The Public API is available to **Team** and **Business** tier workspaces only, and only a **Workspace Owner** can create a token, so a Free workspace has none to create.
+:::
+
+## Prerequisites
+
+- Probo organization administrator access
+- A Segment workspace on the **Team** or **Business** tier
+- The **Workspace Owner** role in Segment (only a Workspace Owner can create a Public API token)
+- The workspace's **Region**, which the Connect dialog asks for alongside the token. Segment calls it the data processing region and sets it when the workspace is created; you cannot change it afterwards. New workspaces default to US, and EU data residency is a Business tier feature that a Segment account executive enables, so a Team workspace is always US
+
+## Collected Fields
+
+| Probo field | Segment field                                            | Notes                                                                                                          |
+| ----------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Name        | `name`                                                   | Falls back to the email address                                                                                |
+| Email       | `email`                                                  |                                                                                                                |
+| Role        | `permissions[].roleName`                                 | Deduplicated and sorted. A pending invitation carries no role                                                  |
+| Admin       | `permissions[].roleName`                                 | Flagged as an administrator when one of the roles is `Workspace Owner`                                         |
+| Status      | `invites`                                                | Pending invitations are listed as inactive. The users endpoint carries no status for members who have accepted, so theirs is left unknown |
+| MFA         | <Badge text="Not supported" class="badge-unsupported" /> |                                                                                                                |
+| Last login  | <Badge text="Not supported" class="badge-unsupported" /> |                                                                                                                |
+| External ID | `id`                                                     | Stable identifier used to track the account across reviews. A pending invitation is keyed by its email address |
+| Created at  | <Badge text="Not supported" class="badge-unsupported" /> |                                                                                                                |
+
+Members who have been invited but have not yet accepted appear alongside accepted members, marked inactive.
+
+## Step 1: Create a Public API Token
+
+import { Steps, Badge } from "@astrojs/starlight/components";
+
+{/* Screenshot pending: save the token-creation dialog to public/docs/access-review/segment-create-api-key.webp and restore the image line here. */}
+
+<Steps>
+
+1. In the [Segment app](https://app.segment.com), signed in as a **Workspace Owner**, go to **Settings** > **Workspace settings** > **Access Management** > **Tokens**.
+2. Click **+ Create Token**, choose a **Public API token**, write a description (e.g. `Probo Access Review`), and assign it **Workspace Owner** access.
+3. Click **Create**, copy the token somewhere secure, and click **Done**.
+
+</Steps>
+
+## Step 2: Connect in Probo
+
+<Steps>
+
+1. In Probo, go to **Access Reviews** > **Sources** > **Add Source**.
+2. Find **Segment**, click **API Key**, paste the token, choose your **Region**, and click **Connect**.
+
+</Steps>
+
+Probo names the source after your workspace and pulls its members into your campaigns.
+
+## Troubleshooting
+
+- **Token creation is unavailable.** The Public API is a Team and Business tier feature, and only a Workspace Owner can create a token. On a Free workspace, upgrade the plan first.
+- **Token rejected.** Confirm it is a Public API token rather than a Config API token, that a Workspace Owner created it, and that the **Region** matches the workspace. Each region has its own host, and a token authenticates against its own workspace's host.
+- **Region unknown.** Segment does not document a settings screen that shows an existing workspace's region, but the URL you sign in with is a practical indicator: `app.segment.com` is the US app and `eu1.app.segment.com` the EU one.
+- **No members appear.** A token with only Workspace Member access may not be able to read the workspace's users. Create one with Workspace Owner access instead.


### PR DESCRIPTION
## Summary

Documentation pages for the two API-key connectors added in getprobo/probo#1482. Both follow `_api-key-template.mdx`; the two OAuth connectors in that PR (Google Analytics, Square) are not covered, since no OAuth connector has a docs page yet and the template is API-key shaped.

- **Dotfile** — workspace API key in the `X-DOTFILE-API-KEY` header. No scopes and no separate key kinds, so the page says that rather than inventing a prefix (none is documented; the only one visible anywhere is in a 2023 screenshot the current OpenAPI spec does not corroborate). The settings path mirrors Dotfile's own wording, because no source documents the console's navigation tree.
- **Segment** — Public API token as a Bearer credential, plus the region that selects the API host. The caution leads with the **Public API vs Config API** distinction, which Segment's own Getting Started calls out and which is the likeliest way to end up with a token that reads nothing. Public API access is Team and Business tier only; EU data residency is Business tier on top of that, so a Team workspace is always US.

Both `<LinkCard>`s are wired into `directory.mdx`.

## Grounding

Every specific traces to the vendor's own current documentation, or is omitted. The field tables come from the drivers in `pkg/accessreview/drivers/`, not from vendor docs, so each `Not supported` row is one the driver genuinely leaves empty. Segment's Status covers pending invitations only, because the users endpoint carries no status for members who have accepted.

Sources: [Dotfile authentication](https://docs.dotfile.com/reference/authentication), [Dotfile roles](https://docs.dotfile.com/docs/roles-and-permissions), [Segment Public API](https://www.twilio.com/docs/segment/api/public-api), [Segment roles](https://www.twilio.com/docs/segment/segment-app/iam/roles), [Public API getting started](https://docs.segmentapis.com/tag/Getting-Started/), [Regional Segment](https://www.twilio.com/docs/segment/guides/regional-segment).

## Screenshots pending

Neither page has one. An MDX comment marks the slot in each:
- `public/docs/access-review/dotfile-create-api-key.webp`
- `public/docs/access-review/segment-create-api-key.webp`

Neither provider offers self-serve access at the tier that can mint the credential — Dotfile is demo-led, and Segment's token screen is gated to Team/Business — so the dialogs could not be captured. The build does not fail on a missing public image.

## Verification

`npm run build` passes locally (234 pages); both pages and the directory cards are emitted. Reviewed by a humanizer pass, a structure/credential audit, an accuracy audit against the vendor docs, and an adversarial pass through Codex.