### PR TITLE
Disable Astro HTML compression to preserve link spacing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,7 @@ function svelteVirtualCssFallback() {
 // https://astro.build/config
 export default defineConfig({
   site: "https://www.probo.com",
+  compressHTML: false,
   prefetch: false,
   trailingSlash: "never",
   redirects: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Astro’s default `compressHTML` was stripping whitespace between text and adjacent tags, so copy like “See the Probo Agent docs” rendered as “See theProbo Agent docs” (visible on https://www.probo.com/download and several hub/blog pages).

## Change

Set `compressHTML: false` in `astro.config.mjs` so source spacing is preserved site-wide, without per-page `{" "}` edits.

## Notes

Slightly larger HTML output; no layout/CSS behavior change beyond keeping intended spaces.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ENG-657](https://linear.app/probo/issue/ENG-657/update-probocom-documentation)

<div><a href="https://cursor.com/agents/bc-da68ae62-2fce-4f44-a0e4-27cf70e47ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-da68ae62-2fce-4f44-a0e4-27cf70e47ef4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

