### PR TITLE
Fix GitHub Star button 404 for unauthenticated visitors

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -26,7 +26,7 @@ type Props = {
       >
       <Button
         variant="secondary"
-        href={`${directMenuItems[1].href}/stargazers`}
+        href={directMenuItems[1].href}
         class="text-sm leading-tight"
       >
         <div class="flex items-center gap-1.5">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The header "Star" button linked to `https://github.com/getprobo/probo/stargazers`, which returns a 404 for visitors who aren't logged into GitHub.

## Change
Point the button at the repository root (`https://github.com/getprobo/probo`) instead of the `/stargazers` path.

## Test plan
- [ ] Click the Star button in the header while logged out of GitHub
- [ ] Confirm it opens the Probo repo page instead of a 404
- [ ] Confirm star count still displays correctly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1c22d93c-e2ed-4dae-b78d-e62e8efdc6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1c22d93c-e2ed-4dae-b78d-e62e8efdc6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

